### PR TITLE
Memoize hooks

### DIFF
--- a/examples/Counter/CounterAppWithHook.tsx
+++ b/examples/Counter/CounterAppWithHook.tsx
@@ -8,20 +8,22 @@ import { colors } from "./constants";
 
 import Button from "./Button";
 
+const stateSelector = {
+  count: selectors.getCounter,
+  isOdd: selectors.getCounterIsOdd,
+  isPositive: selectors.getCounterIsPositive,
+};
+
 export default function Counter() {
   const { decrement, increment, adjust } = useActions(actions);
-  const { count, isOdd, isPositive } = useReduxState({
-    count: selectors.getCounter,
-    isOdd: selectors.getCounterIsOdd,
-    isPositive: selectors.getCounterIsPositive
-  });
+  const { count, isOdd, isPositive } = useReduxState(stateSelector);
 
   const counterStyle: React.CSSProperties = {
     color: isPositive ? (isOdd ? colors.odd : colors.even) : colors.negative,
     fontWeight: "bold",
     paddingLeft: 5,
     paddingRight: 5,
-    width: 50
+    width: 50,
   };
 
   return (


### PR DESCRIPTION
Currently, `useAction` and `useReduxState` do not `useMemo`, which results in potential infinity re-render loop.

This PR:
- added memoize  mechanism to hooks
- refined CounterAppWithHook example: move stateSelector out of component so that each re-render will get the same ref to it.