### PR TITLE
docs: link to live docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ function Counter() {
 }
 ```
 
-→ Full docs: **[getting started](https://github.com/alanrsoares/re-reduced)** ·
-run them with `bun run --filter @re-reduced/docs dev`.
+→ Full docs: **<https://alanrsoares.github.io/re-reduced/>** ·
+run locally with `bun run --filter @re-reduced/docs dev`.
 
 ## Packages
 


### PR DESCRIPTION
Point the README at https://alanrsoares.github.io/re-reduced/ (the live GitHub Pages docs), now that Pages is deployed. Repo website link already updated to the same URL.