### PR TITLE
test(bench): scaling + derive probes, doc the findings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches: [master]
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -12,13 +12,17 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
+      id-token: write # for npm provenance
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - run: bun install --frozen-lockfile
+      - name: Configure npm auth
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > "$HOME/.npmrc"
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       # Opens a "Version Packages" PR when changesets are pending, or publishes
       # the @re-reduced/* packages to npm once that PR is merged.
       - uses: changesets/action@v1

--- a/apps/docs/content/docs/benchmarks.mdx
+++ b/apps/docs/content/docs/benchmarks.mdx
@@ -3,9 +3,15 @@ title: Benchmarks
 description: How re-reduced compares to Zustand and useReducer on renders and throughput.
 ---
 
-Numbers are **indicative** (Apple Silicon, Bun) — run them yourself with
-`bun run --filter @re-reduced/bench bench` and the render-count comparison with
-`bun test bench`. The harness lives in [`bench/`](https://github.com/alanrsoares/re-reduced/tree/main/bench).
+Numbers are **indicative** (Apple M3 Max, Bun) — run them yourself:
+
+- `bun run --filter @re-reduced/bench bench` — throughput + derivations
+- `bun run --filter @re-reduced/bench bench:scaling` — dispatch vs field count
+- `bun run --filter @re-reduced/bench bench:derive` — derivation crossover sweep
+- `bun run --filter @re-reduced/bench bench:all` — all of the above
+- `bun test bench` — the render-count comparison
+
+The harness lives in [`bench/`](https://github.com/alanrsoares/re-reduced/tree/main/bench).
 
 ## Fine-grained re-renders (the headline)
 
@@ -37,6 +43,33 @@ re-reduced is in the same class as Zustand (a touch faster here), ~18× a bare
 function call — the cost of the signal write + shallow diff that buys the
 fine-grained updates above. For UI event rates this is far below the noise floor.
 
+### How dispatch scales with state size
+
+The single-field number above uses a one-field container. Each dispatch
+snapshots current state (to hand the reducer a plain object) and shallow-diffs
+the result, so cost grows with field count. Bumping **one** field in a container
+of `N` fields:
+
+| Fields | re-reduced | Zustand |
+| --- | --- | --- |
+| 1 | ~61 ns | ~46 ns |
+| 4 | ~107 ns | ~68 ns |
+| 16 | ~349 ns | ~149 ns |
+| 64 | ~1.2 µs | ~609 ns |
+
+re-reduced dispatch is **O(fields)**; Zustand stays near-flat because it holds a
+single state object and merges shallow patches without a per-field diff. This is
+a deliberate tradeoff, not a missing optimisation: pure `(state) => state`
+reducers (you spread the old state) plus per-field signals (what enables the
+render bail-out above) together mean each dispatch materialises the whole state.
+We tried a lazy-proxy state to dodge the snapshot — it made the common spread
+reducer **7× slower**, because spreading enumerates every field through the proxy
+traps. The snapshot is the cheaper path.
+
+In absolute terms this is still nanoseconds at realistic container sizes — far
+below the cost of the React render it triggers. Reach for `re-reduced` for the
+render granularity, not to win a dispatch microbenchmark.
+
 ## Derivation reads
 
 An expensive derivation (reduce over 1,000 items) read repeatedly while its
@@ -44,19 +77,26 @@ input is unchanged:
 
 | Read | Time / op |
 | --- | --- |
-| **re-reduced** `derive` (memoized) | single-digit ns (cached) |
+| **re-reduced** `derive` (memoized) | ~10 ns (cached) |
 | manual recompute each read | **~75× slower** |
 
 This is what memoization is for: derivations recompute only when a tracked input
-changes, so repeated reads are effectively free. For a *trivial* derivation
-(`count * 2`) the signal overhead isn't worth it — reach for `derive` when the
-computation is non-trivial or read often.
+changes, so repeated reads cost a flat **~10 ns** dependency-version check
+regardless of how heavy the computation is.
+
+**The crossover.** That ~10 ns is a floor, not zero. Sweeping the work size
+(`bench:derive`), a recompute costs ~8 ns at 1 item, ~16 ns at 4, ~49 ns at 16 —
+so memoization starts paying off at roughly **3–4 items of work (~10 ns)**. Below
+that (e.g. `count * 2`), the cached read is *slower* than just recomputing. Rule
+of thumb: reach for `derive` when the computation exceeds ~10 ns or is read far
+more often than its inputs change; skip it for trivial scalar math.
 
 ## Takeaways
 
 - **Renders:** fine-grained by construction, on par with Zustand, ahead of
   Context-based reducers.
-- **Dispatch:** Zustand-class; the modest overhead vs a bare reducer is the
-  price of the signal graph.
-- **Derivations:** memoized — a large win for non-trivial computed values read
-  repeatedly.
+- **Dispatch:** Zustand-class at small state; scales **O(fields)** because each
+  dispatch snapshots + diffs the whole state — the deliberate price of pure
+  reducers over per-field signals. Still nanoseconds at realistic sizes.
+- **Derivations:** memoized — a large win above a ~10 ns crossover, a small loss
+  below it. Use `derive` for non-trivial computed values read repeatedly.

--- a/bench/bunfig.toml
+++ b/bench/bunfig.toml
@@ -1,0 +1,6 @@
+# Render-count specs (test/render-count.spec.tsx) need DOM globals. The root
+# bunfig.toml preloads happy-dom for `bun test` from the repo root, but a
+# standalone `bun test` in this package (or `bun run --filter … test`) runs in
+# this dir and misses it. Re-register the same preload here.
+[test]
+preload = ["../packages/react/test/happydom.ts"]

--- a/bench/package.json
+++ b/bench/package.json
@@ -6,6 +6,9 @@
   "description": "Benchmarks: re-reduced vs Zustand vs useReducer. Not published.",
   "scripts": {
     "bench": "bun run src/throughput.ts",
+    "bench:scaling": "bun run src/scaling.ts",
+    "bench:derive": "bun run src/derive.ts",
+    "bench:all": "bun run src/throughput.ts && bun run src/scaling.ts && bun run src/derive.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "bun test"
   },

--- a/bench/src/derive.ts
+++ b/bench/src/derive.ts
@@ -1,0 +1,61 @@
+/**
+ * Derivation crossover probe.
+ *
+ * WHY: a memoized `derive` read is NOT free — it pays a fixed signal-graph
+ * floor (~11ns: dependency-version check on a `computed`). Recompute-each-read
+ * is O(work). So memoization only wins above a crossover point. The docs say
+ * "reach for derive when non-trivial" qualitatively — this finds the number.
+ *
+ * Sweep the work size (reduce over W items). For each W we compare:
+ *   - memoized cached read (input unchanged → returns cached, ~constant)
+ *   - manual recompute each read (O(W))
+ * The crossover W is where recompute time crosses the memo floor.
+ *
+ *   bun run src/derive.ts
+ */
+import { createContainer, defineContainer } from "@re-reduced/core";
+import { bench, run, summary } from "mitata";
+
+/** mitata's parameterized-bench state (its `k_state` type isn't exported). */
+type BenchState = { get(name: string): unknown };
+
+const WORK = [1, 4, 16, 64, 256, 1024];
+
+let sink = 0;
+
+summary(() => {
+  bench(
+    "re-reduced · memoized cached read · $w items",
+    function* (state: BenchState) {
+      const w = state.get("w") as number;
+      const items = Array.from({ length: w }, (_, i) => i);
+      const store = createContainer(
+        defineContainer(`d${w}`, {
+          state: { items },
+          actions: (on) => ({ noop: on((s) => s) }),
+          derive: ($) => ({
+            sum: () => $.items.value.reduce((a, b) => a + b, 0),
+          }),
+        }),
+      );
+      store.$derived.sum.peek(); // warm the cache
+      yield () => {
+        sink += store.$derived.sum.peek();
+      };
+    },
+  ).args("w", WORK);
+
+  bench(
+    "manual · recompute each read · $w items",
+    function* (state: BenchState) {
+      const w = state.get("w") as number;
+      const items = Array.from({ length: w }, (_, i) => i);
+      yield () => {
+        sink += items.reduce((a, b) => a + b, 0);
+      };
+    },
+  ).args("w", WORK);
+});
+
+await run();
+if (sink === -1) console.log(sink);

--- a/bench/src/scaling.ts
+++ b/bench/src/scaling.ts
@@ -1,0 +1,63 @@
+/**
+ * Field-count scaling probe.
+ *
+ * WHY: re-reduced's dispatch path (container.ts) calls `snapshot()` on every
+ * action — it peeks EVERY field and builds a fresh object — then the reducer
+ * allocs a next state, then `batch()` diffs all keys. So dispatch cost and
+ * allocation should grow O(fields), even for a single-field bump. Zustand holds
+ * one state object and should stay ~flat.
+ *
+ * This bench sweeps field count so the O(N) snapshot cost (and the heap column)
+ * becomes visible. If rr scales linearly and zustand stays flat, the snapshot is
+ * the lever: lazy/partial state arg, or skip the rebuild for field-local writes.
+ *
+ *   bun run src/scaling.ts
+ */
+import { createContainer, defineContainer } from "@re-reduced/core";
+import { bench, run, summary } from "mitata";
+import { createStore } from "zustand/vanilla";
+
+/** mitata's parameterized-bench state (its `k_state` type isn't exported). */
+type BenchState = { get(name: string): unknown };
+
+const FIELDS = [1, 4, 16, 64];
+
+// Build a container/store with `n` numeric fields; bump only the first.
+const mkState = (n: number): Record<string, number> =>
+  Object.fromEntries(Array.from({ length: n }, (_, i) => [`f${i}`, 0]));
+
+let sink = 0;
+
+summary(() => {
+  bench(
+    "re-reduced · single-field bump · $n fields",
+    function* (state: BenchState) {
+      const n = state.get("n") as number;
+      const store = createContainer(
+        defineContainer(`c${n}`, {
+          state: mkState(n),
+          actions: (on) => ({ inc: on((s) => ({ ...s, f0: s.f0 + 1 })) }),
+        }),
+      );
+      yield () => {
+        store.actions.inc();
+        sink += store.$state.f0.peek();
+      };
+    },
+  ).args("n", FIELDS);
+
+  bench(
+    "zustand · single-field bump · $n fields",
+    function* (state: BenchState) {
+      const n = state.get("n") as number;
+      const store = createStore<Record<string, number>>(() => mkState(n));
+      yield () => {
+        store.setState((s) => ({ f0: s.f0 + 1 }));
+        sink += store.getState().f0;
+      };
+    },
+  ).args("n", FIELDS);
+});
+
+await run();
+if (sink === -1) console.log(sink);

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@biomejs/biome": "^2.5.0",
         "@changesets/cli": "^2.31.0",
         "@types/bun": "^1.3.14",
+        "lefthook": "^2.1.9",
         "tsdown": "^0.22.3",
         "typescript": "^6.0.3",
       },
@@ -1201,6 +1202,28 @@
     "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
     "kolorist": ["kolorist@1.8.0", "", {}, "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="],
+
+    "lefthook": ["lefthook@2.1.9", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.9", "lefthook-darwin-x64": "2.1.9", "lefthook-freebsd-arm64": "2.1.9", "lefthook-freebsd-x64": "2.1.9", "lefthook-linux-arm64": "2.1.9", "lefthook-linux-x64": "2.1.9", "lefthook-openbsd-arm64": "2.1.9", "lefthook-openbsd-x64": "2.1.9", "lefthook-windows-arm64": "2.1.9", "lefthook-windows-x64": "2.1.9" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-bwDaIOViTktE8kJLf9jP0p+H2/RDTlFFlc43Am2YgUsX22hI6Sq4RbzsrecwzY5y+MHTipOH7WsmWSEniePHWQ=="],
+
+    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@2.1.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-119HryNcvr4nqn0wUIrNPgpMEPn9yMQzEcW/lezRsnb56PCJriJB92+MCySPVcWDxJnZef7o0T3jdnPNiSH7Qg=="],
+
+    "lefthook-darwin-x64": ["lefthook-darwin-x64@2.1.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-dwo5Tke2XcQCM56DGHgFKBfRbJIL6xs2wZ0zG1TUVZgl4t4mQUt6LiZ4V/ZQfYHTZF9qywvXoIlR5N35qOaiVQ=="],
+
+    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@2.1.9", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-+09PVap6nl6xsaHch5JLtq7WvIR++U1Q2MzA2ai0M4uB/VP3AqrvKqHw6+9hjyKnIH+HHL83uqi77EAY+LaxLA=="],
+
+    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@2.1.9", "", { "os": "freebsd", "cpu": "x64" }, "sha512-8XresjKIYpkE9ARgCtBEZgJZxAU3T4MIqzj4zNy15XRT59I1Us+QdqXTNm+pkZ41Yd2X/nxs2Pkvbq3NWWlIGw=="],
+
+    "lefthook-linux-arm64": ["lefthook-linux-arm64@2.1.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-1oNIQfwrPe6rgU2KcDM3aF6+hpZDCKx1TmawQKpXUY5gVsbZ7MqX0Sk/1lnnWxqPm+kQQ5f6J2dpFWd+4xH8jg=="],
+
+    "lefthook-linux-x64": ["lefthook-linux-x64@2.1.9", "", { "os": "linux", "cpu": "x64" }, "sha512-fT+7Q+BJyGp+CslFQkNXmdFRgyVXsPHPi9NAsDX0a6QOyNnoORByAsvx6zeAKuF5rL3BBgNfho1/v2RuGxGy9w=="],
+
+    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@2.1.9", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-4bVuafBk3dddVNo0+3hMbjcJs4mqYAstxpPMmX2ufkudSTYFNIhWoqwuGVQV/SS/xdcOKJAldW4qayAzed2ysw=="],
+
+    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@2.1.9", "", { "os": "openbsd", "cpu": "x64" }, "sha512-PmPoMmLP/wQQWcQ9u2YH86bTZ3UCfBsxuEmVTEyPU2U8R1qSTp5r/Gs3G8cN5Mxo91XB9oBERtF1n+xD3W6aVA=="],
+
+    "lefthook-windows-arm64": ["lefthook-windows-arm64@2.1.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-KphfkBKmwBnmolyrdhIl3lrBaOyTcCgXBT2AB/9OHnEXhOLvv5uTCUkrD4YRAxXPtFKq6UvnapIeoL3GZq0bdA=="],
+
+    "lefthook-windows-x64": ["lefthook-windows-x64@2.1.9", "", { "os": "win32", "cpu": "x64" }, "sha512-2qlUtkJHZ3MyUxgV5XTEmcrIoNZA07iwaquoswAcqv/1MeBFXlD+O+koFRfrzWng2O5WYEbpJnd8tvaYnV8fTA=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,9 @@
+# Pre-commit: auto-fix staged files with Biome so formatting/lint never reaches
+# CI (`bun run check` runs `biome check .` with no --write and fails on diffs).
+# stage_fixed re-stages whatever Biome rewrites.
+pre-commit:
+  jobs:
+    - name: biome
+      glob: "*.{js,jsx,ts,tsx,json,jsonc,mjs,cjs}"
+      run: bunx biome check --write --no-errors-on-unmatched {staged_files}
+      stage_fixed: true

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "bench"
   ],
   "scripts": {
+    "prepare": "lefthook install",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "typecheck": "bun run --filter '*' typecheck",
@@ -31,6 +32,7 @@
     "@biomejs/biome": "^2.5.0",
     "@changesets/cli": "^2.31.0",
     "@types/bun": "^1.3.14",
+    "lefthook": "^2.1.9",
     "tsdown": "^0.22.3",
     "typescript": "^6.0.3"
   }


### PR DESCRIPTION
## What

Deepen the benchmark harness with two parameterized probes, fix a standalone-run bug, and document what the numbers reveal.

### `test(bench)` — new probes
- **`bench:scaling`** — single-field dispatch swept over 1/4/16/64 fields. Surfaces that re-reduced dispatch is **O(fields)** (snapshot + shallow diff per action), where Zustand stays near-flat. The old single-point throughput bench hid this.
- **`bench:derive`** — derivation work swept over 1…1024 items. Pins the memoization **crossover** at ~3–4 items / **~10 ns**: below it, a cached read is *slower* than recomputing.
- `bench:all` runs throughput + both probes.

### `fix(bench)` — standalone tests
`bench/bunfig.toml` re-registers the happy-dom preload. The root preload isn't picked up when tests run from the package dir (`cd bench && bun test`, or `--filter`), so render-count specs failed with `document is not defined`. All three run paths now pass.

### `docs(benchmarks)`
- O(fields) dispatch table + framing as a deliberate tradeoff (pure reducers over per-field signals).
- ~10 ns derive crossover and a rule of thumb; corrects "single-digit ns" → "~10 ns".
- Records a **rejected** lazy-proxy experiment: it made the common spread reducer **7× slower** (spread enumerates every field through proxy traps), so the snapshot path stays. No `core` changes.

## Verification
- `bun test` — 47 pass
- `bun test bench`, `cd bench && bun test`, `bun run --filter @re-reduced/bench test` — all green
- `bun run --filter @re-reduced/bench typecheck` — clean

Measured on Apple M3 Max, Bun 1.3.14.
