### PR TITLE
feat: render inspector demo (Game of Life)

### DIFF
--- a/apps/docs/components/demos/render-inspector.tsx
+++ b/apps/docs/components/demos/render-inspector.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+// The whole demo lives in @re-reduced/demos/life — the same component the
+// example app runs. This wrapper just provides the Next.js client boundary and
+// pulls in the demo's stylesheet.
+import "@re-reduced/demos/life.css";
+
+export { RenderInspector } from "@re-reduced/demos/life";

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -10,6 +10,7 @@
     "preact",
     "examples",
     "benchmarks",
+    "render-inspector",
     "agents",
     "migration"
   ]

--- a/apps/docs/content/docs/render-inspector.mdx
+++ b/apps/docs/content/docs/render-inspector.mdx
@@ -1,0 +1,77 @@
+---
+title: Render Inspector
+description: Conway's Game of Life on two state backends at once — watch re-reduced re-render only the cells that changed.
+---
+
+import { RenderInspector } from "@/components/demos/render-inspector";
+
+This is [Conway's Game of Life](https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life)
+running on a grid of DOM nodes, driven by **two state backends at the same
+time** from one set of controls. The board and the actions are shared — the
+_only_ difference is how each side subscribes to state.
+
+Press **Play** (or **Step**), and watch the render pulses and the
+`cell re-renders` counters.
+
+<RenderInspector />
+
+## What you're seeing
+
+Every generation rewrites the whole board, but only a handful of cells actually
+flip. The two backends react very differently:
+
+- **re-reduced** — one signal per cell. A tick dispatches the full next
+  generation; the shallow diff writes only the cells that changed, so only those
+  cells' subscriptions fire. A few dozen DOM updates out of ~900.
+- **`useReducer` + Context** — one state object behind a Context. Any change is a
+  new reference, so every cell consumer re-renders every tick, whether it changed
+  or not. At speed the whole grid strobes and janks.
+
+This is the [fine-grained re-render](/docs/benchmarks#fine-grained-re-renders-the-headline)
+result from the benchmarks, made physical: re-reduced gets per-component bail-out
+**structurally**, from per-field signals, with no hand-written equality
+selectors.
+
+## The honest part
+
+The re-reduced tick is still **O(cells)** in JavaScript — it snapshots and
+diffs every field on each dispatch (see the
+[dispatch scaling](/docs/benchmarks#how-dispatch-scales-with-state-size)
+numbers). But that cost is tens of microseconds; the DOM commit it avoids is
+milliseconds. In the browser, the render savings dominate by orders of
+magnitude — which is why the re-reduced board stays smooth while the Context
+board stutters.
+
+## The container
+
+The board is an ordinary container — one numeric field per cell, a `tick` action
+that returns the next generation, and a memoized `population` derivation:
+
+```ts
+const defineLife = (rc: RecomputeCounter) =>
+  defineContainer("life", {
+    state: emptyBoard(), // { c0: 0, c1: 0, …, c899: 0 }
+    actions: (on) => ({
+      setCell: on((s, p: { i: number; v: number }) => ({ ...s, [`c${p.i}`]: p.v })),
+      tick: on((s) => nextGeneration(s)),
+      load: on((_s, board) => board),
+      clear: on(() => emptyBoard()),
+    }),
+    derive: ($) => ({
+      population: () => CELL_KEYS.reduce((sum, k) => sum + $[k].value, 0),
+    }),
+  });
+```
+
+```tsx
+// each cell subscribes to its OWN signal — re-renders only when that cell flips
+function Cell({ store, i }: { store: LifeStore; i: number }) {
+  const alive = useSelect(store, (s) => s[`c${i}`].value);
+  return <div className={alive ? "cell on" : "cell"} />;
+}
+```
+
+The full runnable app lives under
+[`examples/render-inspector`](https://github.com/alanrsoares/re-reduced/tree/main/examples/render-inspector),
+and the shared component under
+[`packages/demos/src/life.tsx`](https://github.com/alanrsoares/re-reduced/tree/main/packages/demos/src/life.tsx).

--- a/bun.lock
+++ b/bun.lock
@@ -91,6 +91,22 @@
         "vite": "^6.0.0",
       },
     },
+    "examples/render-inspector": {
+      "name": "@re-reduced/example-render-inspector",
+      "version": "0.0.0",
+      "dependencies": {
+        "@re-reduced/demos": "workspace:*",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+      },
+      "devDependencies": {
+        "@testing-library/react": "^16.1.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@vitejs/plugin-react": "^4.3.4",
+        "vite": "^6.0.0",
+      },
+    },
     "packages/adapter-kit": {
       "name": "@re-reduced/adapter-kit",
       "version": "0.1.0",
@@ -608,6 +624,8 @@
     "@re-reduced/example-preact-todo": ["@re-reduced/example-preact-todo@workspace:examples/preact-todo"],
 
     "@re-reduced/example-react-todo": ["@re-reduced/example-react-todo@workspace:examples/react-todo"],
+
+    "@re-reduced/example-render-inspector": ["@re-reduced/example-render-inspector@workspace:examples/render-inspector"],
 
     "@re-reduced/preact": ["@re-reduced/preact@workspace:packages/preact"],
 

--- a/examples/render-inspector/bunfig.toml
+++ b/examples/render-inspector/bunfig.toml
@@ -1,0 +1,5 @@
+# DOM globals for the render test. The root bunfig preloads happy-dom for
+# `bun test` from the repo root, but a standalone run in this package (or
+# --filter) misses it — re-register here. (Same fix as bench/bunfig.toml.)
+[test]
+preload = ["../../packages/react/test/happydom.ts"]

--- a/examples/render-inspector/index.html
+++ b/examples/render-inspector/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>re-reduced · render inspector</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/src/main.tsx"></script>
+	</body>
+</html>

--- a/examples/render-inspector/package.json
+++ b/examples/render-inspector/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@re-reduced/example-render-inspector",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "typecheck": "tsc -p tsconfig.test.json",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@re-reduced/demos": "workspace:*",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.1.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "vite": "^6.0.0"
+  }
+}

--- a/examples/render-inspector/src/App.tsx
+++ b/examples/render-inspector/src/App.tsx
@@ -1,0 +1,3 @@
+// The full demo lives in @re-reduced/demos/life — the same component the docs
+// embed. The example just renders it.
+export { RenderInspector as App } from "@re-reduced/demos/life";

--- a/examples/render-inspector/src/main.tsx
+++ b/examples/render-inspector/src/main.tsx
@@ -1,0 +1,22 @@
+import "@re-reduced/demos/life.css";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+import "./styles.css";
+
+const root = document.getElementById("root");
+if (root)
+  createRoot(root).render(
+    <StrictMode>
+      <main className="page">
+        <h1>Render Inspector</h1>
+        <p className="lede">
+          Conway's Game of Life on a grid of DOM nodes, run on two state
+          backends at once. The board and controls are shared — only the
+          subscription model differs. Watch how many cells each backend
+          re-renders per tick.
+        </p>
+        <App />
+      </main>
+    </StrictMode>,
+  );

--- a/examples/render-inspector/src/styles.css
+++ b/examples/render-inspector/src/styles.css
@@ -1,0 +1,28 @@
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+  background: Canvas;
+  color: CanvasText;
+}
+
+.page {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 2rem 1rem 4rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.page h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.6rem;
+}
+
+.lede {
+  margin: 0 0 1.5rem;
+  max-width: 60ch;
+  line-height: 1.5;
+  opacity: 0.75;
+}

--- a/examples/render-inspector/src/vite-env.d.ts
+++ b/examples/render-inspector/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/render-inspector/test/app.spec.tsx
+++ b/examples/render-inspector/test/app.spec.tsx
@@ -1,0 +1,48 @@
+import { afterEach, expect, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { App } from "../src/App";
+
+afterEach(cleanup);
+
+/** Sum each cell's own cumulative render count (written to `data-r`) for a grid. */
+const renders = (grid: Element) =>
+  Array.from(grid.querySelectorAll<HTMLElement>(".ri-cell")).reduce(
+    (sum, el) => sum + Number(el.dataset.r ?? 0),
+    0,
+  );
+
+const button = (root: HTMLElement, text: string): HTMLButtonElement => {
+  const el = Array.from(root.querySelectorAll("button")).find(
+    (b) => b.textContent === text,
+  );
+  if (!el) throw new Error(`no button "${text}"`);
+  return el;
+};
+
+/**
+ * The thesis, as a test: paint ONE cell and both backends update it, but
+ * re-reduced re-renders ~1 cell while useReducer+Context re-renders the whole
+ * grid (broadcast). Asserted on per-cell render counts (data-r), not the
+ * intentionally-lagging summary badge.
+ */
+test("painting one cell re-renders far fewer cells with re-reduced", () => {
+  const { container } = render(<App />);
+  const [rrGrid, ctxGrid] = container.querySelectorAll(".ri-grid");
+
+  // deterministic baseline: empty board
+  fireEvent.click(button(container, "✕ Clear"));
+  const rrBefore = renders(rrGrid);
+  const ctxBefore = renders(ctxGrid);
+
+  // paint the first cell of the re-reduced grid
+  const firstCell = rrGrid.querySelector(".ri-cell");
+  if (!firstCell) throw new Error("no cells rendered");
+  fireEvent.pointerDown(firstCell);
+
+  const rrDelta = renders(rrGrid) - rrBefore;
+  const ctxDelta = renders(ctxGrid) - ctxBefore;
+
+  expect(rrDelta).toBeGreaterThan(0); // the painted cell re-rendered
+  expect(rrDelta).toBeLessThan(10); // …and essentially nothing else
+  expect(ctxDelta).toBeGreaterThan(rrDelta * 10); // Context re-rendered the grid
+});

--- a/examples/render-inspector/tsconfig.json
+++ b/examples/render-inspector/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "jsx": "react-jsx",
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/examples/render-inspector/tsconfig.test.json
+++ b/examples/render-inspector/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "rootDir": ".",
+    "jsx": "react-jsx",
+    "types": ["bun"],
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src", "test"]
+}

--- a/examples/render-inspector/vite.config.ts
+++ b/examples/render-inspector/vite.config.ts
@@ -1,0 +1,4 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({ plugins: [react()] });

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -12,7 +12,16 @@
     "./react": {
       "types": "./src/react.tsx",
       "default": "./src/react.tsx"
-    }
+    },
+    "./life-store": {
+      "types": "./src/life-store.ts",
+      "default": "./src/life-store.ts"
+    },
+    "./life": {
+      "types": "./src/life.tsx",
+      "default": "./src/life.tsx"
+    },
+    "./life.css": "./src/life.css"
   },
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit"

--- a/packages/demos/src/life-store.ts
+++ b/packages/demos/src/life-store.ts
@@ -1,0 +1,126 @@
+/**
+ * Conway's Game of Life — the write/read-heavy demo that makes re-reduced's
+ * fine-grained reactivity tangible. Every tick rewrites the whole board, but
+ * only a handful of cells actually flip. Two backends, identical board shape:
+ *
+ *  - re-reduced: ONE signal per cell. A tick dispatches a full next-generation
+ *    state; the shallow diff writes only the cells that changed, so only those
+ *    cells' subscribers re-render. On a typical board that's a few dozen DOM
+ *    updates out of ~900.
+ *  - useReducer + Context: ONE state object behind a Context. Any change is a
+ *    new reference, so every one of the ~900 cell consumers re-renders every
+ *    tick — even the cells that didn't change.
+ *
+ * Honesty note: the re-reduced tick is O(cells) (snapshot + diff — see the
+ * `bench/` scaling probe). In a browser that JS cost (~tens of µs) is dwarfed
+ * by the DOM commit it avoids, which is why the rr board stays smooth while the
+ * Context board janks at speed.
+ */
+import { type ActionSpec, defineContainer, type Store } from "@re-reduced/core";
+
+export const ROWS = 30;
+export const COLS = 30;
+export const CELL_COUNT = ROWS * COLS;
+
+/** Flat index → state key. Cells are fields `c0`…`c899`, values 0 | 1. */
+export const cellKey = (i: number) => `c${i}`;
+export const CELL_KEYS = Array.from({ length: CELL_COUNT }, (_, i) =>
+  cellKey(i),
+);
+
+export type LifeState = Record<string, number>;
+
+export const emptyBoard = (): LifeState => {
+  const state: LifeState = {};
+  for (const key of CELL_KEYS) state[key] = 0;
+  return state;
+};
+
+/** Seed ~`density` fraction of cells alive. `rand` injected so callers control RNG. */
+export const randomBoard = (density: number, rand: () => number): LifeState => {
+  const state: LifeState = {};
+  for (const key of CELL_KEYS) state[key] = rand() < density ? 1 : 0;
+  return state;
+};
+
+/** Toroidal next generation — standard B3/S23 rules, wrapping at the edges. */
+export const nextGeneration = (s: LifeState): LifeState => {
+  const next: LifeState = {};
+  for (let r = 0; r < ROWS; r++) {
+    for (let c = 0; c < COLS; c++) {
+      let alive = 0;
+      for (let dr = -1; dr <= 1; dr++) {
+        for (let dc = -1; dc <= 1; dc++) {
+          if (dr === 0 && dc === 0) continue;
+          const nr = (r + dr + ROWS) % ROWS;
+          const nc = (c + dc + COLS) % COLS;
+          alive += s[cellKey(nr * COLS + nc)];
+        }
+      }
+      const i = cellKey(r * COLS + c);
+      const live = s[i] === 1;
+      next[i] = (live ? alive === 2 || alive === 3 : alive === 3) ? 1 : 0;
+    }
+  }
+  return next;
+};
+
+export const population = (s: LifeState): number => {
+  let n = 0;
+  for (const key of CELL_KEYS) n += s[key];
+  return n;
+};
+
+/** Mutable tally of how often the `population` derivation actually recomputed. */
+export type RecomputeCounter = { count: number };
+
+/** The re-reduced container: one signal per cell + a memoized `population`. */
+export const defineLife = (rc: RecomputeCounter) =>
+  defineContainer("life", {
+    state: emptyBoard(),
+    actions: (on) => ({
+      setCell: on((s, p: { i: number; v: number }) => ({
+        ...s,
+        [cellKey(p.i)]: p.v,
+      })),
+      tick: on((s) => nextGeneration(s)),
+      load: on((_s, board: LifeState) => board),
+      clear: on(() => emptyBoard()),
+    }),
+    derive: ($) => ({
+      population: () => {
+        rc.count += 1;
+        return CELL_KEYS.reduce((sum, key) => sum + $[key].value, 0);
+      },
+    }),
+  });
+
+/** Concrete store type so the React view can type cell props without `any`. */
+export type LifeActions = {
+  setCell: ActionSpec<LifeState, { i: number; v: number }>;
+  tick: ActionSpec<LifeState, void>;
+  load: ActionSpec<LifeState, LifeState>;
+  clear: ActionSpec<LifeState, void>;
+};
+export type LifeDerived = { population: () => number };
+export type LifeStore = Store<LifeState, LifeActions, LifeDerived>;
+
+// ── naive useReducer + Context backend (same board, no fine-grained reads) ──
+export type LifeAction =
+  | { type: "setCell"; i: number; v: number }
+  | { type: "tick" }
+  | { type: "load"; board: LifeState }
+  | { type: "clear" };
+
+export const lifeReducer = (s: LifeState, a: LifeAction): LifeState => {
+  switch (a.type) {
+    case "setCell":
+      return { ...s, [cellKey(a.i)]: a.v };
+    case "tick":
+      return nextGeneration(s);
+    case "load":
+      return a.board;
+    case "clear":
+      return emptyBoard();
+  }
+};

--- a/packages/demos/src/life.css
+++ b/packages/demos/src/life.css
@@ -1,24 +1,35 @@
+/*
+ * Colors resolve from fumadocs tokens when present (so the demo follows the
+ * docs light/dark toggle automatically), and fall back to literals + a
+ * prefers-color-scheme override for the standalone Vite example.
+ */
 .ri {
-  --ri-border: #d4d4d8;
-  --ri-bg: #fafafa;
-  --ri-cell: #e7e7ea;
+  --ri-border: var(--color-fd-border, #d4d4d8);
+  --ri-bg: var(--color-fd-card, #fafafa);
+  --ri-cell: var(--color-fd-muted, #e7e7ea);
+  /* fixed, legible accent (NOT fd-primary — that's near-white in dark) */
   --ri-on: #2563eb;
+  --ri-text: var(--color-fd-foreground, #18181b);
+  --ri-dim: var(--color-fd-muted-foreground, #71717a);
   --ri-pulse: #f59e0b;
-  --ri-text: #18181b;
-  --ri-dim: #71717a;
+  --ri-good: #16a34a;
+  --ri-bad: #e11d48;
+  max-width: 100%;
   font-family: system-ui, -apple-system, sans-serif;
   color: var(--ri-text);
 }
 
+/* dark fallbacks for the example app (no fumadocs tokens, no theme class) */
 @media (prefers-color-scheme: dark) {
   .ri {
-    --ri-border: #3f3f46;
-    --ri-bg: #18181b;
-    --ri-cell: #27272a;
-    --ri-on: #60a5fa;
-    --ri-pulse: #fbbf24;
-    --ri-text: #f4f4f5;
-    --ri-dim: #a1a1aa;
+    --ri-border: var(--color-fd-border, #3f3f46);
+    --ri-bg: var(--color-fd-card, #18181b);
+    --ri-cell: var(--color-fd-muted, #27272a);
+    --ri-on: #3b82f6;
+    --ri-text: var(--color-fd-foreground, #f4f4f5);
+    --ri-dim: var(--color-fd-muted-foreground, #a1a1aa);
+    --ri-good: #22c55e;
+    --ri-bad: #fb7185;
   }
 }
 
@@ -26,8 +37,13 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 0.75rem;
+  gap: 0.85rem;
+  margin-bottom: 0.4rem;
+}
+.ri-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
 }
 
 .ri-btn {
@@ -38,6 +54,7 @@
   padding: 0.35rem 0.7rem;
   font-size: 0.85rem;
   cursor: pointer;
+  white-space: nowrap;
 }
 .ri-btn:hover {
   border-color: var(--ri-on);
@@ -51,6 +68,10 @@
   border-color: var(--ri-on);
   color: #fff;
 }
+.ri-primary:hover {
+  filter: brightness(1.08);
+  border-color: var(--ri-on);
+}
 
 .ri-field {
   display: inline-flex;
@@ -60,10 +81,38 @@
   color: var(--ri-dim);
 }
 
+.ri-seg {
+  display: inline-flex;
+}
+.ri-seg .ri-btn {
+  border-radius: 0;
+  border-left-width: 0;
+}
+.ri-seg .ri-btn:first-child {
+  border-radius: 8px 0 0 8px;
+  border-left-width: 1px;
+}
+.ri-seg .ri-btn:last-child {
+  border-radius: 0 8px 8px 0;
+}
+.ri-on-seg {
+  background: var(--ri-on);
+  border-color: var(--ri-on);
+  color: #fff;
+  font-weight: 600;
+}
+
+.ri-draw-hint {
+  margin: 0 0 0.75rem;
+  font-size: 0.75rem;
+  color: var(--ri-dim);
+}
+
 .ri-boards {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 1rem;
+  min-width: 0;
 }
 @media (max-width: 720px) {
   .ri-boards {
@@ -71,7 +120,16 @@
   }
 }
 
+.ri-wrap {
+  min-width: 0;
+  transition: opacity 0.2s;
+}
+.ri-idle {
+  opacity: 0.4;
+}
+
 .ri-panel {
+  min-width: 0;
   border: 1px solid var(--ri-border);
   border-radius: 12px;
   padding: 0.75rem;
@@ -79,14 +137,22 @@
 }
 .ri-panel-head {
   display: flex;
+  flex-wrap: wrap;
   align-items: baseline;
   justify-content: space-between;
-  gap: 0.5rem;
+  gap: 0.15rem 0.5rem;
 }
 .ri-badge {
   font-variant-numeric: tabular-nums;
   font-size: 0.75rem;
+  font-weight: 600;
   color: var(--ri-dim);
+}
+.ri-badge.ri-good {
+  color: var(--ri-good);
+}
+.ri-badge.ri-bad {
+  color: var(--ri-bad);
 }
 .ri-sub {
   margin: 0.15rem 0 0.6rem;
@@ -97,8 +163,10 @@
 .ri-grid {
   display: grid;
   gap: 1px;
+  min-width: 0;
   touch-action: none;
   user-select: none;
+  cursor: crosshair;
 }
 
 .ri-cell {
@@ -127,17 +195,39 @@
     opacity: 0;
   }
 }
+@media (prefers-reduced-motion: reduce) {
+  .ri-pulse {
+    animation: none;
+    opacity: 0;
+  }
+}
 
 .ri-stats {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 0.5rem;
+  grid-template-columns: repeat(4, 1fr);
+  grid-auto-rows: 1fr;
+  gap: 0.6rem;
   margin: 0.9rem 0 0;
 }
 .ri-stats > div {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.25rem;
   border: 1px solid var(--ri-border);
-  border-radius: 8px;
-  padding: 0.5rem 0.6rem;
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+  background: var(--ri-bg);
+}
+/* bento accents: the punchline spans 2×2, the perf pairs span 2 wide */
+.ri-feat {
+  grid-column: span 2;
+  grid-row: span 2;
+  background: color-mix(in srgb, var(--ri-on) 8%, var(--ri-bg));
+  border-color: color-mix(in srgb, var(--ri-on) 35%, var(--ri-border));
+}
+.ri-wide {
+  grid-column: span 2;
 }
 .ri-stats dt {
   font-size: 0.72rem;
@@ -145,9 +235,24 @@
   margin: 0;
 }
 .ri-stats dd {
-  margin: 0.2rem 0 0;
+  margin: 0;
   font-size: 1.1rem;
   font-weight: 600;
+}
+.ri-feat dt {
+  font-size: 0.8rem;
+}
+.ri-feat dd {
+  font-size: 2.4rem;
+  line-height: 1.1;
+}
+@media (max-width: 720px) {
+  .ri-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .ri-feat {
+    grid-row: span 1;
+  }
 }
 .ri-mono {
   font-variant-numeric: tabular-nums;
@@ -156,6 +261,18 @@
 .ri-dim {
   color: var(--ri-dim);
   font-weight: 400;
+}
+.ri-rr {
+  color: var(--ri-good);
+}
+.ri-ctx {
+  color: var(--ri-bad);
+}
+
+.ri-hint {
+  margin: 0.6rem 0 0;
+  font-size: 0.78rem;
+  color: var(--ri-dim);
 }
 
 .ri-note {

--- a/packages/demos/src/life.css
+++ b/packages/demos/src/life.css
@@ -1,0 +1,166 @@
+.ri {
+  --ri-border: #d4d4d8;
+  --ri-bg: #fafafa;
+  --ri-cell: #e7e7ea;
+  --ri-on: #2563eb;
+  --ri-pulse: #f59e0b;
+  --ri-text: #18181b;
+  --ri-dim: #71717a;
+  font-family: system-ui, -apple-system, sans-serif;
+  color: var(--ri-text);
+}
+
+@media (prefers-color-scheme: dark) {
+  .ri {
+    --ri-border: #3f3f46;
+    --ri-bg: #18181b;
+    --ri-cell: #27272a;
+    --ri-on: #60a5fa;
+    --ri-pulse: #fbbf24;
+    --ri-text: #f4f4f5;
+    --ri-dim: #a1a1aa;
+  }
+}
+
+.ri-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.ri-btn {
+  border: 1px solid var(--ri-border);
+  background: var(--ri-bg);
+  color: var(--ri-text);
+  border-radius: 8px;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+.ri-btn:hover {
+  border-color: var(--ri-on);
+}
+.ri-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.ri-primary {
+  background: var(--ri-on);
+  border-color: var(--ri-on);
+  color: #fff;
+}
+
+.ri-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  color: var(--ri-dim);
+}
+
+.ri-boards {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+@media (max-width: 720px) {
+  .ri-boards {
+    grid-template-columns: 1fr;
+  }
+}
+
+.ri-panel {
+  border: 1px solid var(--ri-border);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background: var(--ri-bg);
+}
+.ri-panel-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+.ri-badge {
+  font-variant-numeric: tabular-nums;
+  font-size: 0.75rem;
+  color: var(--ri-dim);
+}
+.ri-sub {
+  margin: 0.15rem 0 0.6rem;
+  font-size: 0.75rem;
+  color: var(--ri-dim);
+}
+
+.ri-grid {
+  display: grid;
+  gap: 1px;
+  touch-action: none;
+  user-select: none;
+}
+
+.ri-cell {
+  position: relative;
+  aspect-ratio: 1;
+  background: var(--ri-cell);
+  border-radius: 1px;
+  overflow: hidden;
+}
+.ri-cell.ri-on {
+  background: var(--ri-on);
+}
+
+.ri-pulse {
+  position: absolute;
+  inset: 0;
+  background: var(--ri-pulse);
+  animation: ri-fade 0.45s ease-out forwards;
+  pointer-events: none;
+}
+@keyframes ri-fade {
+  from {
+    opacity: 0.85;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+.ri-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.5rem;
+  margin: 0.9rem 0 0;
+}
+.ri-stats > div {
+  border: 1px solid var(--ri-border);
+  border-radius: 8px;
+  padding: 0.5rem 0.6rem;
+}
+.ri-stats dt {
+  font-size: 0.72rem;
+  color: var(--ri-dim);
+  margin: 0;
+}
+.ri-stats dd {
+  margin: 0.2rem 0 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+.ri-mono {
+  font-variant-numeric: tabular-nums;
+  font-family: ui-monospace, "SF Mono", monospace;
+}
+.ri-dim {
+  color: var(--ri-dim);
+  font-weight: 400;
+}
+
+.ri-note {
+  margin: 0.9rem 0 0;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: var(--ri-dim);
+}

--- a/packages/demos/src/life.tsx
+++ b/packages/demos/src/life.tsx
@@ -2,6 +2,8 @@ import { useContainer, useSelect } from "@re-reduced/react";
 import {
   createContext,
   memo,
+  Profiler,
+  type ProfilerOnRenderCallback,
   type ReactNode,
   useCallback,
   useContext,
@@ -28,7 +30,7 @@ import {
 /** Per-board cumulative render tally — mutated in cell render bodies. */
 type Stats = { renders: number };
 
-const gridStyle = { gridTemplateColumns: `repeat(${COLS}, 1fr)` };
+const gridStyle = { gridTemplateColumns: `repeat(${COLS}, minmax(0, 1fr))` };
 
 const LifeCtx = createContext<LifeState>(emptyBoard());
 
@@ -171,12 +173,14 @@ function Panel({
   title,
   subtitle,
   renders,
+  tone,
   badgeTestId,
   children,
 }: {
   title: string;
   subtitle: string;
   renders: number;
+  tone: "good" | "bad";
   badgeTestId: string;
   children: ReactNode;
 }) {
@@ -184,7 +188,7 @@ function Panel({
     <div className="ri-panel">
       <div className="ri-panel-head">
         <strong>{title}</strong>
-        <span className="ri-badge" data-testid={badgeTestId}>
+        <span className={`ri-badge ri-${tone}`} data-testid={badgeTestId}>
           {renders.toLocaleString()} cell re-renders
         </span>
       </div>
@@ -216,8 +220,36 @@ export function RenderInspector() {
 
   const [gen, setGen] = useState(0);
   const [running, setRunning] = useState(false);
+  const [raf, setRaf] = useState(false);
   const [speed, setSpeed] = useState(6);
   const [pulse, setPulse] = useState(true);
+  // Which backend(s) the run loop drives. Isolate one to measure its true
+  // sustained FPS without the other contending for the same frame budget.
+  const [active, setActive] = useState<"both" | "rr" | "ctx">("both");
+  const runRR = active !== "ctx";
+  const runCtx = active !== "rr";
+
+  // Per-board render time, measured independently so the slow Context board
+  // doesn't just gate one shared frame number. (React fires onRender only in
+  // dev / profiling builds — production reads 0, shown as "—".)
+  const rrProf = useRef({ ms: 0, commits: 0 });
+  const ctxProf = useRef({ ms: 0, commits: 0 });
+  const fps = useRef({ frames: 0, since: 0, value: 0 });
+
+  const onRRRender = useCallback<ProfilerOnRenderCallback>(
+    (_id, _p, actual) => {
+      rrProf.current.ms += actual;
+      rrProf.current.commits += 1;
+    },
+    [],
+  );
+  const onCtxRender = useCallback<ProfilerOnRenderCallback>(
+    (_id, _p, actual) => {
+      ctxProf.current.ms += actual;
+      ctxProf.current.commits += 1;
+    },
+    [],
+  );
 
   const paint = useCallback(
     (i: number) => {
@@ -228,10 +260,10 @@ export function RenderInspector() {
   );
 
   const step = useCallback(() => {
-    rrStore.actions.tick();
-    ctxDispatch({ type: "tick" });
+    if (active !== "ctx") rrStore.actions.tick();
+    if (active !== "rr") ctxDispatch({ type: "tick" });
     setGen((g) => g + 1);
-  }, [rrStore]);
+  }, [rrStore, active]);
 
   const randomize = useCallback(() => {
     const board = randomBoard(0.3, Math.random);
@@ -251,15 +283,46 @@ export function RenderInspector() {
     rrStats.current.renders = 0;
     ctxStats.current.renders = 0;
     rrRc.current.count = 0;
+    rrProf.current = { ms: 0, commits: 0 };
+    ctxProf.current = { ms: 0, commits: 0 };
+    fps.current = { frames: 0, since: 0, value: 0 };
     force();
   }, []);
 
-  // run loop
+  // fixed-rate run loop (Play)
   useEffect(() => {
-    if (!running) return;
+    if (!running || raf) return;
     const id = setInterval(step, Math.max(33, Math.round(1000 / speed)));
     return () => clearInterval(id);
-  }, [running, speed, step]);
+  }, [running, raf, speed, step]);
+
+  // max-rate run loop (rAF) — ticks as fast as the frame budget allows
+  useEffect(() => {
+    if (!raf) return;
+    let id = 0;
+    const loop = (t: number) => {
+      const f = fps.current;
+      if (f.since === 0) f.since = t;
+      f.frames += 1;
+      if (t - f.since >= 400) {
+        f.value = (f.frames * 1000) / (t - f.since);
+        f.frames = 0;
+        f.since = t;
+      }
+      if (active !== "ctx") rrStore.actions.tick();
+      if (active !== "rr") ctxDispatch({ type: "tick" });
+      setGen((g) => g + 1);
+      id = requestAnimationFrame(loop);
+    };
+    id = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(id);
+  }, [raf, rrStore, active]);
+
+  // measurements are only meaningful within one run mode — reset on change
+  // biome-ignore lint/correctness/useExhaustiveDependencies: resetStats is stable
+  useEffect(() => {
+    resetStats();
+  }, [active, raf]);
 
   // seed a board on mount
   useEffect(() => {
@@ -269,100 +332,194 @@ export function RenderInspector() {
   const rrPop = rrStore.$derived.population.peek();
   const ctxPop = population(ctxBoard);
 
+  // Only report a backend's timing while it's actually being driven — a paused
+  // board's last (near-zero) commit would otherwise divide into a junk FPS.
+  const rrMs =
+    runRR && rrProf.current.commits
+      ? rrProf.current.ms / rrProf.current.commits
+      : 0;
+  const ctxMs =
+    runCtx && ctxProf.current.commits
+      ? ctxProf.current.ms / ctxProf.current.commits
+      : 0;
+  const rrFps = rrMs ? Math.round(1000 / rrMs) : 0;
+  const ctxFps = ctxMs ? Math.round(1000 / ctxMs) : 0;
+
   return (
     <div className="ri not-prose">
       <div className="ri-controls">
-        <button
-          type="button"
-          className="ri-btn ri-primary"
-          onClick={() => setRunning((r) => !r)}
-        >
-          {running ? "⏸ Pause" : "▶ Play"}
-        </button>
-        <button
-          type="button"
-          className="ri-btn"
-          onClick={step}
-          disabled={running}
-        >
-          ⏭ Step
-        </button>
-        <button type="button" className="ri-btn" onClick={randomize}>
-          🎲 Randomize
-        </button>
-        <button type="button" className="ri-btn" onClick={clear}>
-          ✕ Clear
-        </button>
-        <button type="button" className="ri-btn" onClick={resetStats}>
-          ↺ Reset counts
-        </button>
-        <label className="ri-field">
-          Speed
-          <input
-            type="range"
-            min={1}
-            max={15}
-            value={speed}
-            onChange={(e) => setSpeed(Number(e.target.value))}
-          />
-          <span className="ri-mono">{speed}/s</span>
-        </label>
-        <label className="ri-field">
-          <input
-            type="checkbox"
-            checked={pulse}
-            onChange={(e) => setPulse(e.target.checked)}
-          />
-          Render pulse
-        </label>
+        <span className="ri-group">
+          <button
+            type="button"
+            className="ri-btn ri-primary"
+            onClick={() => setRunning((r) => !r)}
+            disabled={raf}
+          >
+            {running ? "⏸ Pause" : "▶ Play"}
+          </button>
+          <button
+            type="button"
+            className={raf ? "ri-btn ri-primary" : "ri-btn"}
+            onClick={() => setRaf((v) => !v)}
+            disabled={running}
+          >
+            {raf ? "⏹ Stop max" : "⚡ Max (rAF)"}
+          </button>
+          <button
+            type="button"
+            className="ri-btn"
+            onClick={step}
+            disabled={running || raf}
+          >
+            ⏭ Step
+          </button>
+        </span>
+
+        <span className="ri-group">
+          <button type="button" className="ri-btn" onClick={randomize}>
+            🎲 Randomize
+          </button>
+          <button type="button" className="ri-btn" onClick={clear}>
+            ✕ Clear
+          </button>
+          <button type="button" className="ri-btn" onClick={resetStats}>
+            ↺ Reset counts
+          </button>
+        </span>
+
+        <span className="ri-seg">
+          {(["both", "rr", "ctx"] as const).map((m) => (
+            <button
+              key={m}
+              type="button"
+              className={active === m ? "ri-btn ri-on-seg" : "ri-btn"}
+              onClick={() => setActive(m)}
+            >
+              {m === "both" ? "Both" : m === "rr" ? "rr only" : "ctx only"}
+            </button>
+          ))}
+        </span>
+
+        <span className="ri-group">
+          <label className="ri-field">
+            Speed
+            <input
+              type="range"
+              min={1}
+              max={15}
+              value={speed}
+              onChange={(e) => setSpeed(Number(e.target.value))}
+            />
+            <span className="ri-mono">{speed}/s</span>
+          </label>
+          <label className="ri-field">
+            <input
+              type="checkbox"
+              checked={pulse}
+              onChange={(e) => setPulse(e.target.checked)}
+            />
+            Render pulse
+          </label>
+        </span>
       </div>
+      <p className="ri-draw-hint">✎ Drag on either grid to draw cells.</p>
 
       <div className="ri-boards">
-        <Panel
-          title="re-reduced"
-          subtitle="one signal per cell — only flipped cells re-render"
-          renders={rrStats.current.renders}
-          badgeTestId="rr-renders"
-        >
-          <RRBoard
-            store={rrStore}
-            stats={rrStats.current}
-            onPaint={paint}
-            pulse={pulse}
-          />
-        </Panel>
+        <div className={runRR ? "ri-wrap" : "ri-wrap ri-idle"}>
+          <Panel
+            title="re-reduced"
+            subtitle="one signal per cell — only flipped cells re-render"
+            renders={rrStats.current.renders}
+            tone="good"
+            badgeTestId="rr-renders"
+          >
+            <Profiler id="rr" onRender={onRRRender}>
+              <RRBoard
+                store={rrStore}
+                stats={rrStats.current}
+                onPaint={paint}
+                pulse={pulse}
+              />
+            </Profiler>
+          </Panel>
+        </div>
 
-        <Panel
-          title="useReducer + Context"
-          subtitle="one state object — every cell re-renders each tick"
-          renders={ctxStats.current.renders}
-          badgeTestId="ctx-renders"
-        >
-          <LifeCtx.Provider value={ctxBoard}>
-            <CtxBoard stats={ctxStats.current} onPaint={paint} pulse={pulse} />
-          </LifeCtx.Provider>
-        </Panel>
+        <div className={runCtx ? "ri-wrap" : "ri-wrap ri-idle"}>
+          <Panel
+            title="useReducer + Context"
+            subtitle="one state object — every cell re-renders each tick"
+            renders={ctxStats.current.renders}
+            tone="bad"
+            badgeTestId="ctx-renders"
+          >
+            <Profiler id="ctx" onRender={onCtxRender}>
+              <LifeCtx.Provider value={ctxBoard}>
+                <CtxBoard
+                  stats={ctxStats.current}
+                  onPaint={paint}
+                  pulse={pulse}
+                />
+              </LifeCtx.Provider>
+            </Profiler>
+          </Panel>
+        </div>
       </div>
 
       <dl className="ri-stats">
-        <div>
-          <dt>Generation</dt>
-          <dd className="ri-mono">{gen}</dd>
-        </div>
-        <div>
-          <dt>Population</dt>
-          <dd className="ri-mono">
-            {rrPop} / {ctxPop}
-          </dd>
-        </div>
-        <div>
+        <div className="ri-feat">
           <dt>
-            re-render ratio <span className="ri-dim">(context ÷ rr)</span>
+            cell re-renders{" "}
+            <span className="ri-dim">(Context vs re-reduced)</span>
           </dt>
           <dd className="ri-mono">
             {rrStats.current.renders > 0
               ? `${(ctxStats.current.renders / rrStats.current.renders).toFixed(1)}×`
               : "—"}
+          </dd>
+          <dt className="ri-dim">
+            fewer with re-reduced ·{" "}
+            <span className="ri-rr">
+              {rrStats.current.renders.toLocaleString()}
+            </span>{" "}
+            vs{" "}
+            <span className="ri-ctx">
+              {ctxStats.current.renders.toLocaleString()}
+            </span>
+          </dt>
+        </div>
+        <div className="ri-wide">
+          <dt>
+            renders / sec <span className="ri-dim">(per backend)</span>
+          </dt>
+          <dd className="ri-mono">
+            <span className="ri-rr">{rrFps || "—"}</span> /{" "}
+            <span className="ri-ctx">{ctxFps || "—"}</span>
+          </dd>
+        </div>
+        <div className="ri-wide">
+          <dt>
+            render time / tick <span className="ri-dim">(ms · rr / ctx)</span>
+          </dt>
+          <dd className="ri-mono">
+            <span className="ri-rr">{rrMs ? rrMs.toFixed(2) : "—"}</span> /{" "}
+            <span className="ri-ctx">{ctxMs ? ctxMs.toFixed(2) : "—"}</span>
+          </dd>
+        </div>
+        <div>
+          <dt>
+            loop FPS <span className="ri-dim">(rAF, {active})</span>
+          </dt>
+          <dd className="ri-mono">
+            {raf ? Math.round(fps.current.value) : "—"}
+          </dd>
+        </div>
+        <div>
+          <dt>
+            population <span className="ri-dim">(rr / ctx)</span>
+          </dt>
+          <dd className="ri-mono">
+            <span className="ri-rr">{rrPop}</span> /{" "}
+            <span className="ri-ctx">{ctxPop}</span>
           </dd>
         </div>
         <div>
@@ -372,15 +529,38 @@ export function RenderInspector() {
           </dt>
           <dd className="ri-mono">{rrRc.current.count}</dd>
         </div>
+        <div>
+          <dt>Generation</dt>
+          <dd className="ri-mono">{gen}</dd>
+        </div>
       </dl>
 
+      {!raf && rrFps === 0 && ctxFps === 0 && (
+        <p className="ri-hint">
+          Timing populates once it runs. For a clean per-backend FPS, switch to{" "}
+          <strong>rr only</strong> / <strong>ctx only</strong> and hit{" "}
+          <strong>⚡ Max (rAF)</strong> so the other board isn't sharing the
+          frame.
+        </p>
+      )}
+
       <p className="ri-note">
-        Draw with the mouse on either grid. Both backends share the same board
-        and controls — the <em>only</em> difference is how each subscribes.
-        Watch the pulse: re-reduced lights up just the cells that flipped;
-        Context strobes the whole grid every tick. The re-reduced tick is still
-        O(cells) in JS (snapshot + diff — see the benchmarks), but it avoids the
-        DOM commit that makes the Context board jank at speed.
+        Both backends share the same board and controls — the <em>only</em>{" "}
+        difference is how each subscribes. Watch the pulse: re-reduced lights up
+        just the cells that flipped; Context strobes the whole grid every tick.
+        The re-reduced tick is still O(cells) in JS (snapshot + diff — see the
+        benchmarks), but it avoids the DOM commit that makes the Context board
+        jank at speed.
+      </p>
+      <p className="ri-note">
+        <strong>Reading the FPS fairly.</strong> <em>render ms / tick</em> is
+        per-backend and stays clean even with both running — React renders each
+        board's subtree sequentially and the <code>Profiler</code> times each on
+        its own. <em>loop FPS</em> is the shared frame budget, so it reflects
+        whatever is active: to read a backend's <em>true</em> sustained FPS,
+        switch <em>Both → rr only / ctx only</em> so the other isn't contending.
+        (Render timing needs React's dev/profiling build; a production bundle
+        shows “—”.)
       </p>
     </div>
   );

--- a/packages/demos/src/life.tsx
+++ b/packages/demos/src/life.tsx
@@ -1,0 +1,387 @@
+import { useContainer, useSelect } from "@re-reduced/react";
+import {
+  createContext,
+  memo,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
+import {
+  CELL_KEYS,
+  COLS,
+  cellKey,
+  defineLife,
+  emptyBoard,
+  type LifeState,
+  type LifeStore,
+  lifeReducer,
+  population,
+  type RecomputeCounter,
+  randomBoard,
+} from "./life-store";
+
+/** Per-board cumulative render tally — mutated in cell render bodies. */
+type Stats = { renders: number };
+
+const gridStyle = { gridTemplateColumns: `repeat(${COLS}, 1fr)` };
+
+const LifeCtx = createContext<LifeState>(emptyBoard());
+
+// ── presentational cell (shared by both backends) ──
+function Cell({
+  alive,
+  i,
+  onPaint,
+  pulse,
+  r,
+}: {
+  alive: boolean;
+  i: number;
+  onPaint: (i: number) => void;
+  pulse: boolean;
+  r: number;
+}) {
+  return (
+    <div
+      className={alive ? "ri-cell ri-on" : "ri-cell"}
+      data-r={r}
+      onPointerDown={(e) => {
+        e.preventDefault();
+        onPaint(i);
+      }}
+      onPointerEnter={(e) => {
+        if (e.buttons === 1) onPaint(i);
+      }}
+    >
+      {/* keyed remount replays the pulse animation on every render */}
+      {pulse && <span className="ri-pulse" key={r} />}
+    </div>
+  );
+}
+
+// ── re-reduced cell: subscribes to ONE cell signal → re-renders only on flip ──
+function RRCell({
+  store,
+  i,
+  stats,
+  onPaint,
+  pulse,
+}: {
+  store: LifeStore;
+  i: number;
+  stats: Stats;
+  onPaint: (i: number) => void;
+  pulse: boolean;
+}) {
+  const v = useSelect(store, (s) => s[cellKey(i)].value);
+  stats.renders += 1;
+  const r = useRef(0);
+  r.current += 1;
+  return (
+    <Cell alive={v === 1} i={i} onPaint={onPaint} pulse={pulse} r={r.current} />
+  );
+}
+
+const RRBoard = memo(function RRBoard({
+  store,
+  stats,
+  onPaint,
+  pulse,
+}: {
+  store: LifeStore;
+  stats: Stats;
+  onPaint: (i: number) => void;
+  pulse: boolean;
+}) {
+  return (
+    <div className="ri-grid" style={gridStyle}>
+      {CELL_KEYS.map((_, i) => (
+        <RRCell
+          // biome-ignore lint/suspicious/noArrayIndexKey: cells are a fixed-length grid
+          key={i}
+          store={store}
+          i={i}
+          stats={stats}
+          onPaint={onPaint}
+          pulse={pulse}
+        />
+      ))}
+    </div>
+  );
+});
+
+// ── Context cell: reads the whole board → re-renders on ANY change (broadcast) ──
+function CtxCell({
+  i,
+  stats,
+  onPaint,
+  pulse,
+}: {
+  i: number;
+  stats: Stats;
+  onPaint: (i: number) => void;
+  pulse: boolean;
+}) {
+  const board = useContext(LifeCtx);
+  stats.renders += 1;
+  const r = useRef(0);
+  r.current += 1;
+  return (
+    <Cell
+      alive={board[cellKey(i)] === 1}
+      i={i}
+      onPaint={onPaint}
+      pulse={pulse}
+      r={r.current}
+    />
+  );
+}
+
+const CtxBoard = memo(function CtxBoard({
+  stats,
+  onPaint,
+  pulse,
+}: {
+  stats: Stats;
+  onPaint: (i: number) => void;
+  pulse: boolean;
+}) {
+  return (
+    <div className="ri-grid" style={gridStyle}>
+      {CELL_KEYS.map((_, i) => (
+        <CtxCell
+          // biome-ignore lint/suspicious/noArrayIndexKey: cells are a fixed-length grid
+          key={i}
+          i={i}
+          stats={stats}
+          onPaint={onPaint}
+          pulse={pulse}
+        />
+      ))}
+    </div>
+  );
+});
+
+function Panel({
+  title,
+  subtitle,
+  renders,
+  badgeTestId,
+  children,
+}: {
+  title: string;
+  subtitle: string;
+  renders: number;
+  badgeTestId: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="ri-panel">
+      <div className="ri-panel-head">
+        <strong>{title}</strong>
+        <span className="ri-badge" data-testid={badgeTestId}>
+          {renders.toLocaleString()} cell re-renders
+        </span>
+      </div>
+      <p className="ri-sub">{subtitle}</p>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Render Inspector — Conway's Game of Life on a {ROWS}×{COLS} grid of DOM nodes,
+ * run on two backends at once from one set of controls. Watch the cell-re-render
+ * counters and the render pulses: re-reduced updates only flipped cells; the
+ * Context backend re-renders the whole grid every tick.
+ */
+export function RenderInspector() {
+  const rrRc = useRef<RecomputeCounter>({ count: 0 });
+  const def = useMemo(() => defineLife(rrRc.current), []);
+  const rrStore: LifeStore = useContainer(def);
+  const [ctxBoard, ctxDispatch] = useReducer(
+    lifeReducer,
+    undefined,
+    emptyBoard,
+  );
+
+  const rrStats = useRef<Stats>({ renders: 0 });
+  const ctxStats = useRef<Stats>({ renders: 0 });
+  const [, force] = useReducer((n: number) => n + 1, 0);
+
+  const [gen, setGen] = useState(0);
+  const [running, setRunning] = useState(false);
+  const [speed, setSpeed] = useState(6);
+  const [pulse, setPulse] = useState(true);
+
+  const paint = useCallback(
+    (i: number) => {
+      rrStore.actions.setCell({ i, v: 1 });
+      ctxDispatch({ type: "setCell", i, v: 1 });
+    },
+    [rrStore],
+  );
+
+  const step = useCallback(() => {
+    rrStore.actions.tick();
+    ctxDispatch({ type: "tick" });
+    setGen((g) => g + 1);
+  }, [rrStore]);
+
+  const randomize = useCallback(() => {
+    const board = randomBoard(0.3, Math.random);
+    rrStore.actions.load(board);
+    ctxDispatch({ type: "load", board });
+    setGen(0);
+  }, [rrStore]);
+
+  const clear = useCallback(() => {
+    setRunning(false);
+    rrStore.actions.clear();
+    ctxDispatch({ type: "clear" });
+    setGen(0);
+  }, [rrStore]);
+
+  const resetStats = useCallback(() => {
+    rrStats.current.renders = 0;
+    ctxStats.current.renders = 0;
+    rrRc.current.count = 0;
+    force();
+  }, []);
+
+  // run loop
+  useEffect(() => {
+    if (!running) return;
+    const id = setInterval(step, Math.max(33, Math.round(1000 / speed)));
+    return () => clearInterval(id);
+  }, [running, speed, step]);
+
+  // seed a board on mount
+  useEffect(() => {
+    randomize();
+  }, [randomize]);
+
+  const rrPop = rrStore.$derived.population.peek();
+  const ctxPop = population(ctxBoard);
+
+  return (
+    <div className="ri not-prose">
+      <div className="ri-controls">
+        <button
+          type="button"
+          className="ri-btn ri-primary"
+          onClick={() => setRunning((r) => !r)}
+        >
+          {running ? "⏸ Pause" : "▶ Play"}
+        </button>
+        <button
+          type="button"
+          className="ri-btn"
+          onClick={step}
+          disabled={running}
+        >
+          ⏭ Step
+        </button>
+        <button type="button" className="ri-btn" onClick={randomize}>
+          🎲 Randomize
+        </button>
+        <button type="button" className="ri-btn" onClick={clear}>
+          ✕ Clear
+        </button>
+        <button type="button" className="ri-btn" onClick={resetStats}>
+          ↺ Reset counts
+        </button>
+        <label className="ri-field">
+          Speed
+          <input
+            type="range"
+            min={1}
+            max={15}
+            value={speed}
+            onChange={(e) => setSpeed(Number(e.target.value))}
+          />
+          <span className="ri-mono">{speed}/s</span>
+        </label>
+        <label className="ri-field">
+          <input
+            type="checkbox"
+            checked={pulse}
+            onChange={(e) => setPulse(e.target.checked)}
+          />
+          Render pulse
+        </label>
+      </div>
+
+      <div className="ri-boards">
+        <Panel
+          title="re-reduced"
+          subtitle="one signal per cell — only flipped cells re-render"
+          renders={rrStats.current.renders}
+          badgeTestId="rr-renders"
+        >
+          <RRBoard
+            store={rrStore}
+            stats={rrStats.current}
+            onPaint={paint}
+            pulse={pulse}
+          />
+        </Panel>
+
+        <Panel
+          title="useReducer + Context"
+          subtitle="one state object — every cell re-renders each tick"
+          renders={ctxStats.current.renders}
+          badgeTestId="ctx-renders"
+        >
+          <LifeCtx.Provider value={ctxBoard}>
+            <CtxBoard stats={ctxStats.current} onPaint={paint} pulse={pulse} />
+          </LifeCtx.Provider>
+        </Panel>
+      </div>
+
+      <dl className="ri-stats">
+        <div>
+          <dt>Generation</dt>
+          <dd className="ri-mono">{gen}</dd>
+        </div>
+        <div>
+          <dt>Population</dt>
+          <dd className="ri-mono">
+            {rrPop} / {ctxPop}
+          </dd>
+        </div>
+        <div>
+          <dt>
+            re-render ratio <span className="ri-dim">(context ÷ rr)</span>
+          </dt>
+          <dd className="ri-mono">
+            {rrStats.current.renders > 0
+              ? `${(ctxStats.current.renders / rrStats.current.renders).toFixed(1)}×`
+              : "—"}
+          </dd>
+        </div>
+        <div>
+          <dt>
+            <code>population</code> recomputes{" "}
+            <span className="ri-dim">(rr, memoized)</span>
+          </dt>
+          <dd className="ri-mono">{rrRc.current.count}</dd>
+        </div>
+      </dl>
+
+      <p className="ri-note">
+        Draw with the mouse on either grid. Both backends share the same board
+        and controls — the <em>only</em> difference is how each subscribes.
+        Watch the pulse: re-reduced lights up just the cells that flipped;
+        Context strobes the whole grid every tick. The re-reduced tick is still
+        O(cells) in JS (snapshot + diff — see the benchmarks), but it avoids the
+        DOM commit that makes the Context board jank at speed.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a Game of Life render-inspector demo: per-cell signals (re-reduced) vs `useReducer`+Context on the same 30×30 board, driven by one set of controls, so the fine-grained render benefit is visible — rr re-renders only flipped cells, Context re-renders the whole grid every tick.
- Add a **Max (rAF)** mode that ticks at frame rate, with per-backend render time measured via React `Profiler` (isolated even when both boards run) and a **Both / rr only / ctx only** selector to read a backend's true sustained FPS without frame contention.
- Live **bento stats**: headline "N× fewer re-renders", per-backend renders/sec and render-time/tick, population, memoized recomputes, generation — colour-coded rr (green) / ctx (red).
- Shared component + container live in `packages/demos` (`life-store.ts`, `life.tsx`, `life.css`); consumed by a new Vite app `examples/render-inspector` and embedded in the docs.
- Example ships a render-count test asserting one painted cell re-renders ~1 cell with re-reduced vs the whole grid with Context.
- New `/docs/render-inspector` page embeds the live demo, links to the fine-grained-render and dispatch-scaling benchmark sections, and is honest that the rr tick is O(cells) in JS but dominated by the DOM commit it avoids.
- UX: follows the docs light/dark theme, no mobile horizontal overflow, reduced-motion support, single legible primary action.