### PR TITLE
docs: use fumadocs Steps, Tabs, and Callout

### DIFF
--- a/apps/docs/content/docs/benchmarks.mdx
+++ b/apps/docs/content/docs/benchmarks.mdx
@@ -3,7 +3,13 @@ title: Benchmarks
 description: How re-reduced compares to Zustand and useReducer on renders and throughput.
 ---
 
-Numbers are **indicative** (Apple M3 Max, Bun) — run them yourself:
+<Callout type="info">
+  Numbers are **indicative** (Apple M3 Max, Bun) — your hardware will differ.
+  Run them yourself; the harness lives in
+  [`bench/`](https://github.com/alanrsoares/re-reduced/tree/main/bench).
+</Callout>
+
+Run them yourself:
 
 - `bun run --filter @re-reduced/bench bench` — throughput + derivations
 - `bun run --filter @re-reduced/bench bench:scaling` — dispatch vs field count

--- a/apps/docs/content/docs/getting-started.mdx
+++ b/apps/docs/content/docs/getting-started.mdx
@@ -3,19 +3,40 @@ title: Getting started
 description: Install re-reduced and wire your first container.
 ---
 
-## Install
+<Steps>
+
+<Step>
+
+### Install
 
 Pick the renderer package — it re-exports the core, so it's the only dependency
 you need to import from.
 
+<Tabs items={["React", "Preact"]}>
+
+<Tab value="React">
+
 ```bash
-# React
 bun add @re-reduced/react @preact/signals-core
-# Preact
+```
+
+</Tab>
+
+<Tab value="Preact">
+
+```bash
 bun add @re-reduced/preact @preact/signals-core @preact/signals
 ```
 
-## Define a container
+</Tab>
+
+</Tabs>
+
+</Step>
+
+<Step>
+
+### Define a container
 
 A **container definition** is framework-agnostic — pure state, actions, and
 derivations. No React, no I/O.
@@ -36,12 +57,18 @@ export const counter = defineContainer("counter", {
 });
 ```
 
-`defineContainer(name, def)` is a single call. State, actions, and derivations
-are inferred from the body; the effect-intent union is inferred from the
-reactions the `effects` block returns (see [Effects](/docs/effects)) — no type
-arguments needed.
+<Callout>
+  `defineContainer(name, def)` is a single call. State, actions, and derivations
+  are inferred from the body; the effect-intent union is inferred from the
+  reactions the `effects` block returns (see [Effects](/docs/effects)) — no type
+  arguments needed.
+</Callout>
 
-## Use it in a component
+</Step>
+
+<Step>
+
+### Use it in a component
 
 ```tsx title="Counter.tsx"
 import { useContainer, useSelect } from "@re-reduced/react";
@@ -67,7 +94,11 @@ export function Counter() {
 - `useSelect(store, selector)` subscribes to a derived slice and re-renders the
   component **only when that value changes**.
 
-## Share across a subtree
+</Step>
+
+<Step>
+
+### Share across a subtree
 
 ```tsx
 const CounterCtx = createContainerContext(counter);
@@ -77,5 +108,11 @@ const CounterCtx = createContainerContext(counter);
 </CounterCtx.Provider>;
 ```
 
-`init` is applied at construction and is **not** reactive — to reset, dispatch
-an action.
+<Callout type="warn">
+  `init` is applied at construction and is **not** reactive — to reset, dispatch
+  an action.
+</Callout>
+
+</Step>
+
+</Steps>

--- a/apps/docs/content/docs/render-inspector.mdx
+++ b/apps/docs/content/docs/render-inspector.mdx
@@ -10,8 +10,11 @@ running on a grid of DOM nodes, driven by **two state backends at the same
 time** from one set of controls. The board and the actions are shared — the
 _only_ difference is how each side subscribes to state.
 
-Press **Play** (or **Step**), and watch the render pulses and the
-`cell re-renders` counters.
+<Callout title="Try it">
+  Press **Play** (or **Step**) and watch the render pulses and the
+  `cell re-renders` counters. Drag on a grid to draw; switch to **rr only** /
+  **ctx only** with **⚡ Max (rAF)** to read each backend's true FPS.
+</Callout>
 
 <RenderInspector />
 
@@ -34,13 +37,15 @@ selectors.
 
 ## The honest part
 
-The re-reduced tick is still **O(cells)** in JavaScript — it snapshots and
-diffs every field on each dispatch (see the
-[dispatch scaling](/docs/benchmarks#how-dispatch-scales-with-state-size)
-numbers). But that cost is tens of microseconds; the DOM commit it avoids is
-milliseconds. In the browser, the render savings dominate by orders of
-magnitude — which is why the re-reduced board stays smooth while the Context
-board stutters.
+<Callout type="warn">
+  The re-reduced tick is still **O(cells)** in JavaScript — it snapshots and
+  diffs every field on each dispatch (see the
+  [dispatch scaling](/docs/benchmarks#how-dispatch-scales-with-state-size)
+  numbers). But that cost is tens of microseconds; the DOM commit it avoids is
+  milliseconds. In the browser, the render savings dominate by orders of
+  magnitude — which is why the re-reduced board stays smooth while the Context
+  board stutters.
+</Callout>
 
 ## The container
 


### PR DESCRIPTION
## Summary
- `getting-started` now reads as numbered `<Steps>` with a React/Preact install `<Tabs>` group, instead of flat `##` sections and a combined bash block.
- `benchmarks` and `render-inspector` use `<Callout>` for the indicative-numbers note and the O(cells) / "try it" asides, instead of plain bold prose.
- No setup changes needed — the demo already consumes `--color-fd-*` tokens and follows the docs theme, the `neutral` preset is imported, and `getMDXComponents` already registers Tabs/Steps alongside the defaults (which include Callout).