### PR TITLE
refactor(demos): decompose render inspector

### DIFF
--- a/bench/src/_mitata.ts
+++ b/bench/src/_mitata.ts
@@ -1,0 +1,2 @@
+/** mitata's parameterized-bench state (its `k_state` type isn't exported). */
+export type BenchState = { get(name: string): unknown };

--- a/bench/src/derive.ts
+++ b/bench/src/derive.ts
@@ -15,9 +15,7 @@
  */
 import { createContainer, defineContainer } from "@re-reduced/core";
 import { bench, run, summary } from "mitata";
-
-/** mitata's parameterized-bench state (its `k_state` type isn't exported). */
-type BenchState = { get(name: string): unknown };
+import type { BenchState } from "./_mitata";
 
 const WORK = [1, 4, 16, 64, 256, 1024];
 

--- a/bench/src/scaling.ts
+++ b/bench/src/scaling.ts
@@ -16,9 +16,7 @@
 import { createContainer, defineContainer } from "@re-reduced/core";
 import { bench, run, summary } from "mitata";
 import { createStore } from "zustand/vanilla";
-
-/** mitata's parameterized-bench state (its `k_state` type isn't exported). */
-type BenchState = { get(name: string): unknown };
+import type { BenchState } from "./_mitata";
 
 const FIELDS = [1, 4, 16, 64];
 

--- a/packages/demos/src/life-boards.tsx
+++ b/packages/demos/src/life-boards.tsx
@@ -1,0 +1,157 @@
+/**
+ * The two boards the Render Inspector contrasts, plus their shared cell. Both
+ * render an identical {@link Cell} grid — the *only* difference is how each cell
+ * subscribes: re-reduced reads one per-cell signal, Context reads the whole
+ * board. That contrast is the demo's whole point, so the two stay deliberately
+ * parallel; the render-counting plumbing they share lives in `./life-metrics`.
+ */
+import { useSelect } from "@re-reduced/react";
+import { createContext, memo, type ReactNode, useContext } from "react";
+import { type Tally, useRenderTally } from "./life-metrics";
+import {
+  CELL_KEYS,
+  COLS,
+  cellKey,
+  emptyBoard,
+  type LifeState,
+  type LifeStore,
+} from "./life-store";
+
+const gridStyle = { gridTemplateColumns: `repeat(${COLS}, minmax(0, 1fr))` };
+
+export const LifeCtx = createContext<LifeState>(emptyBoard());
+
+type CellProps = {
+  alive: boolean;
+  i: number;
+  onPaint: (i: number) => void;
+  pulse: boolean;
+  r: number;
+};
+
+// ── presentational cell (shared by both backends) ──
+function Cell({ alive, i, onPaint, pulse, r }: CellProps) {
+  return (
+    <div
+      className={alive ? "ri-cell ri-on" : "ri-cell"}
+      data-r={r}
+      onPointerDown={(e) => {
+        e.preventDefault();
+        onPaint(i);
+      }}
+      onPointerEnter={(e) => {
+        if (e.buttons === 1) onPaint(i);
+      }}
+    >
+      {/* keyed remount replays the pulse animation on every render */}
+      {pulse && <span className="ri-pulse" key={r} />}
+    </div>
+  );
+}
+
+type BoardProps = {
+  stats: Tally;
+  onPaint: (i: number) => void;
+  pulse: boolean;
+};
+
+// ── re-reduced cell: subscribes to ONE cell signal → re-renders only on flip ──
+function RRCell({
+  store,
+  i,
+  stats,
+  onPaint,
+  pulse,
+}: BoardProps & { store: LifeStore; i: number }) {
+  const v = useSelect(store, (s) => s[cellKey(i)].value);
+  const r = useRenderTally(stats);
+  return <Cell alive={v === 1} i={i} onPaint={onPaint} pulse={pulse} r={r} />;
+}
+
+export const RRBoard = memo(function RRBoard({
+  store,
+  stats,
+  onPaint,
+  pulse,
+}: BoardProps & { store: LifeStore }) {
+  return (
+    <div className="ri-grid" style={gridStyle}>
+      {CELL_KEYS.map((_, i) => (
+        <RRCell
+          // biome-ignore lint/suspicious/noArrayIndexKey: cells are a fixed-length grid
+          key={i}
+          store={store}
+          i={i}
+          stats={stats}
+          onPaint={onPaint}
+          pulse={pulse}
+        />
+      ))}
+    </div>
+  );
+});
+
+// ── Context cell: reads the whole board → re-renders on ANY change (broadcast) ──
+function CtxCell({ i, stats, onPaint, pulse }: BoardProps & { i: number }) {
+  const board = useContext(LifeCtx);
+  const r = useRenderTally(stats);
+  return (
+    <Cell
+      alive={board[cellKey(i)] === 1}
+      i={i}
+      onPaint={onPaint}
+      pulse={pulse}
+      r={r}
+    />
+  );
+}
+
+export const CtxBoard = memo(function CtxBoard({
+  stats,
+  onPaint,
+  pulse,
+}: BoardProps) {
+  return (
+    <div className="ri-grid" style={gridStyle}>
+      {CELL_KEYS.map((_, i) => (
+        <CtxCell
+          // biome-ignore lint/suspicious/noArrayIndexKey: cells are a fixed-length grid
+          key={i}
+          i={i}
+          stats={stats}
+          onPaint={onPaint}
+          pulse={pulse}
+        />
+      ))}
+    </div>
+  );
+});
+
+export function Panel({
+  title,
+  subtitle,
+  renders,
+  tone,
+  badgeTestId,
+  children,
+}: {
+  title: string;
+  subtitle: string;
+  renders: number;
+  tone: "good" | "bad";
+  badgeTestId: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="ri-panel">
+      <div className="ri-panel-head">
+        <strong>{title}</strong>
+        <span className={`ri-badge ri-${tone}`} data-testid={badgeTestId}>
+          {renders.toLocaleString()} cell re-renders
+        </span>
+      </div>
+      <p className="ri-sub">{subtitle}</p>
+      {children}
+    </div>
+  );
+}

--- a/packages/demos/src/life-controls.tsx
+++ b/packages/demos/src/life-controls.tsx
@@ -1,0 +1,120 @@
+/**
+ * The Render Inspector's control bar. The run state is a single 3-way mode —
+ * `idle | play | max` — so the buttons toggle one union instead of juggling two
+ * mutually-exclusive booleans with hand-written cross-`disabled` guards.
+ */
+import type { Dispatch, SetStateAction } from "react";
+
+/** Run loop: stopped, fixed-rate (`setInterval`), or max-rate (`rAF`). */
+export type RunMode = "idle" | "play" | "max";
+/** Which backend(s) the run loop drives. */
+export type Active = "both" | "rr" | "ctx";
+
+export function Controls({
+  mode,
+  setMode,
+  active,
+  setActive,
+  speed,
+  setSpeed,
+  pulse,
+  setPulse,
+  onStep,
+  onRandomize,
+  onClear,
+  onResetStats,
+}: {
+  mode: RunMode;
+  setMode: Dispatch<SetStateAction<RunMode>>;
+  active: Active;
+  setActive: Dispatch<SetStateAction<Active>>;
+  speed: number;
+  setSpeed: Dispatch<SetStateAction<number>>;
+  pulse: boolean;
+  setPulse: Dispatch<SetStateAction<boolean>>;
+  onStep: () => void;
+  onRandomize: () => void;
+  onClear: () => void;
+  onResetStats: () => void;
+}) {
+  return (
+    <>
+      <div className="ri-controls">
+        <span className="ri-group">
+          <button
+            type="button"
+            className="ri-btn ri-primary"
+            onClick={() => setMode((m) => (m === "play" ? "idle" : "play"))}
+            disabled={mode === "max"}
+          >
+            {mode === "play" ? "⏸ Pause" : "▶ Play"}
+          </button>
+          <button
+            type="button"
+            className={mode === "max" ? "ri-btn ri-primary" : "ri-btn"}
+            onClick={() => setMode((m) => (m === "max" ? "idle" : "max"))}
+            disabled={mode === "play"}
+          >
+            {mode === "max" ? "⏹ Stop max" : "⚡ Max (rAF)"}
+          </button>
+          <button
+            type="button"
+            className="ri-btn"
+            onClick={onStep}
+            disabled={mode !== "idle"}
+          >
+            ⏭ Step
+          </button>
+        </span>
+
+        <span className="ri-group">
+          <button type="button" className="ri-btn" onClick={onRandomize}>
+            🎲 Randomize
+          </button>
+          <button type="button" className="ri-btn" onClick={onClear}>
+            ✕ Clear
+          </button>
+          <button type="button" className="ri-btn" onClick={onResetStats}>
+            ↺ Reset counts
+          </button>
+        </span>
+
+        <span className="ri-seg">
+          {(["both", "rr", "ctx"] as const).map((m) => (
+            <button
+              key={m}
+              type="button"
+              className={active === m ? "ri-btn ri-on-seg" : "ri-btn"}
+              onClick={() => setActive(m)}
+            >
+              {m === "both" ? "Both" : m === "rr" ? "rr only" : "ctx only"}
+            </button>
+          ))}
+        </span>
+
+        <span className="ri-group">
+          <label className="ri-field">
+            Speed
+            <input
+              type="range"
+              min={1}
+              max={15}
+              value={speed}
+              onChange={(e) => setSpeed(Number(e.target.value))}
+            />
+            <span className="ri-mono">{speed}/s</span>
+          </label>
+          <label className="ri-field">
+            <input
+              type="checkbox"
+              checked={pulse}
+              onChange={(e) => setPulse(e.target.checked)}
+            />
+            Render pulse
+          </label>
+        </span>
+      </div>
+      <p className="ri-draw-hint">✎ Drag on either grid to draw cells.</p>
+    </>
+  );
+}

--- a/packages/demos/src/life-metrics.ts
+++ b/packages/demos/src/life-metrics.ts
@@ -1,0 +1,64 @@
+/**
+ * Per-backend measurement plumbing for the Render Inspector. Both backends
+ * (re-reduced and useReducer+Context) track the same two things — a cumulative
+ * cell-render tally and accumulated React Profiler timing — so the bookkeeping
+ * lives here once instead of being duplicated per backend in the view.
+ */
+import {
+  type ProfilerOnRenderCallback,
+  useCallback,
+  useMemo,
+  useRef,
+} from "react";
+
+/** Per-board cumulative render tally — mutated in cell render bodies. */
+export type Tally = { renders: number };
+/** Accumulated React Profiler timing for one board. */
+export type Prof = { ms: number; commits: number };
+
+export type Backend = {
+  stats: { current: Tally };
+  prof: { current: Prof };
+  onRender: ProfilerOnRenderCallback;
+};
+
+/**
+ * One backend's render tally + Profiler accumulator + commit callback. Returns a
+ * stable object so it can sit in `useCallback`/`useEffect` dependency lists.
+ */
+export function useBackend(): Backend {
+  const stats = useRef<Tally>({ renders: 0 });
+  const prof = useRef<Prof>({ ms: 0, commits: 0 });
+  const onRender = useCallback<ProfilerOnRenderCallback>(
+    (_id, _phase, actual) => {
+      prof.current.ms += actual;
+      prof.current.commits += 1;
+    },
+    [],
+  );
+  return useMemo(() => ({ stats, prof, onRender }), [onRender]);
+}
+
+/** Zero a backend's accumulators (between run modes / on demand). */
+export function resetBackend(b: Backend): void {
+  b.stats.current.renders = 0;
+  b.prof.current = { ms: 0, commits: 0 };
+}
+
+/**
+ * Mean render time per commit — 0 while the board is idle or never committed, so
+ * a paused board's stale last commit can't divide into a junk FPS.
+ */
+export const perTick = (prof: Prof, running: boolean): number =>
+  running && prof.commits ? prof.ms / prof.commits : 0;
+
+/**
+ * Count this cell's own renders: bump the shared tally and a per-cell ref.
+ * Returns the per-cell render number (written to `data-r`, which the test sums).
+ */
+export function useRenderTally(stats: Tally): number {
+  stats.renders += 1;
+  const r = useRef(0);
+  r.current += 1;
+  return r.current;
+}

--- a/packages/demos/src/life-stats.tsx
+++ b/packages/demos/src/life-stats.tsx
@@ -1,0 +1,118 @@
+/**
+ * The Render Inspector's metrics readout — the `<dl>` of per-backend counts plus
+ * the explanatory notes on how to read them fairly.
+ */
+import type { Active } from "./life-controls";
+
+/** One backend's live numbers for the readout. */
+type Metrics = { renders: number; fps: number; ms: number; pop: number };
+
+export function StatsPanel({
+  rr,
+  ctx,
+  loopFps,
+  active,
+  popRecomputes,
+  gen,
+}: {
+  rr: Metrics;
+  ctx: Metrics;
+  /** rAF loop frame rate, or null when the max-rate loop isn't running. */
+  loopFps: number | null;
+  active: Active;
+  popRecomputes: number;
+  gen: number;
+}) {
+  return (
+    <>
+      <dl className="ri-stats">
+        <div className="ri-feat">
+          <dt>
+            cell re-renders{" "}
+            <span className="ri-dim">(Context vs re-reduced)</span>
+          </dt>
+          <dd className="ri-mono">
+            {rr.renders > 0 ? `${(ctx.renders / rr.renders).toFixed(1)}×` : "—"}
+          </dd>
+          <dt className="ri-dim">
+            fewer with re-reduced ·{" "}
+            <span className="ri-rr">{rr.renders.toLocaleString()}</span> vs{" "}
+            <span className="ri-ctx">{ctx.renders.toLocaleString()}</span>
+          </dt>
+        </div>
+        <div className="ri-wide">
+          <dt>
+            renders / sec <span className="ri-dim">(per backend)</span>
+          </dt>
+          <dd className="ri-mono">
+            <span className="ri-rr">{rr.fps || "—"}</span> /{" "}
+            <span className="ri-ctx">{ctx.fps || "—"}</span>
+          </dd>
+        </div>
+        <div className="ri-wide">
+          <dt>
+            render time / tick <span className="ri-dim">(ms · rr / ctx)</span>
+          </dt>
+          <dd className="ri-mono">
+            <span className="ri-rr">{rr.ms ? rr.ms.toFixed(2) : "—"}</span> /{" "}
+            <span className="ri-ctx">{ctx.ms ? ctx.ms.toFixed(2) : "—"}</span>
+          </dd>
+        </div>
+        <div>
+          <dt>
+            loop FPS <span className="ri-dim">(rAF, {active})</span>
+          </dt>
+          <dd className="ri-mono">{loopFps ?? "—"}</dd>
+        </div>
+        <div>
+          <dt>
+            population <span className="ri-dim">(rr / ctx)</span>
+          </dt>
+          <dd className="ri-mono">
+            <span className="ri-rr">{rr.pop}</span> /{" "}
+            <span className="ri-ctx">{ctx.pop}</span>
+          </dd>
+        </div>
+        <div>
+          <dt>
+            <code>population</code> recomputes{" "}
+            <span className="ri-dim">(rr, memoized)</span>
+          </dt>
+          <dd className="ri-mono">{popRecomputes}</dd>
+        </div>
+        <div>
+          <dt>Generation</dt>
+          <dd className="ri-mono">{gen}</dd>
+        </div>
+      </dl>
+
+      {loopFps === null && rr.fps === 0 && ctx.fps === 0 && (
+        <p className="ri-hint">
+          Timing populates once it runs. For a clean per-backend FPS, switch to{" "}
+          <strong>rr only</strong> / <strong>ctx only</strong> and hit{" "}
+          <strong>⚡ Max (rAF)</strong> so the other board isn't sharing the
+          frame.
+        </p>
+      )}
+
+      <p className="ri-note">
+        Both backends share the same board and controls — the <em>only</em>{" "}
+        difference is how each subscribes. Watch the pulse: re-reduced lights up
+        just the cells that flipped; Context strobes the whole grid every tick.
+        The re-reduced tick is still O(cells) in JS (snapshot + diff — see the
+        benchmarks), but it avoids the DOM commit that makes the Context board
+        jank at speed.
+      </p>
+      <p className="ri-note">
+        <strong>Reading the FPS fairly.</strong> <em>render ms / tick</em> is
+        per-backend and stays clean even with both running — React renders each
+        board's subtree sequentially and the <code>Profiler</code> times each on
+        its own. <em>loop FPS</em> is the shared frame budget, so it reflects
+        whatever is active: to read a backend's <em>true</em> sustained FPS,
+        switch <em>Both → rr only / ctx only</em> so the other isn't contending.
+        (Render timing needs React's dev/profiling build; a production bundle
+        shows “—”.)
+      </p>
+    </>
+  );
+}

--- a/packages/demos/src/life-store.ts
+++ b/packages/demos/src/life-store.ts
@@ -28,7 +28,9 @@ export const CELL_KEYS = Array.from({ length: CELL_COUNT }, (_, i) =>
   cellKey(i),
 );
 
-export type LifeState = Record<string, number>;
+/** A cell is dead (0) or alive (1) — the board never holds any other value. */
+export type Cell = 0 | 1;
+export type LifeState = Record<string, Cell>;
 
 export const emptyBoard = (): LifeState => {
   const state: LifeState = {};
@@ -79,7 +81,7 @@ export const defineLife = (rc: RecomputeCounter) =>
   defineContainer("life", {
     state: emptyBoard(),
     actions: (on) => ({
-      setCell: on((s, p: { i: number; v: number }) => ({
+      setCell: on((s, p: { i: number; v: Cell }) => ({
         ...s,
         [cellKey(p.i)]: p.v,
       })),
@@ -97,7 +99,7 @@ export const defineLife = (rc: RecomputeCounter) =>
 
 /** Concrete store type so the React view can type cell props without `any`. */
 export type LifeActions = {
-  setCell: ActionSpec<LifeState, { i: number; v: number }>;
+  setCell: ActionSpec<LifeState, { i: number; v: Cell }>;
   tick: ActionSpec<LifeState, void>;
   load: ActionSpec<LifeState, LifeState>;
   clear: ActionSpec<LifeState, void>;
@@ -107,7 +109,7 @@ export type LifeStore = Store<LifeState, LifeActions, LifeDerived>;
 
 // ── naive useReducer + Context backend (same board, no fine-grained reads) ──
 export type LifeAction =
-  | { type: "setCell"; i: number; v: number }
+  | { type: "setCell"; i: number; v: Cell }
   | { type: "tick" }
   | { type: "load"; board: LifeState }
   | { type: "clear" };

--- a/packages/demos/src/life.tsx
+++ b/packages/demos/src/life.tsx
@@ -1,25 +1,20 @@
-import { useContainer, useSelect } from "@re-reduced/react";
+import { useContainer } from "@re-reduced/react";
 import {
-  createContext,
-  memo,
   Profiler,
-  type ProfilerOnRenderCallback,
-  type ReactNode,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useReducer,
   useRef,
   useState,
 } from "react";
+import { CtxBoard, LifeCtx, Panel, RRBoard } from "./life-boards";
+import { type Active, Controls, type RunMode } from "./life-controls";
+import { perTick, resetBackend, useBackend } from "./life-metrics";
+import { StatsPanel } from "./life-stats";
 import {
-  CELL_KEYS,
-  COLS,
-  cellKey,
   defineLife,
   emptyBoard,
-  type LifeState,
   type LifeStore,
   lifeReducer,
   population,
@@ -27,182 +22,15 @@ import {
   randomBoard,
 } from "./life-store";
 
-/** Per-board cumulative render tally — mutated in cell render bodies. */
-type Stats = { renders: number };
-
-const gridStyle = { gridTemplateColumns: `repeat(${COLS}, minmax(0, 1fr))` };
-
-const LifeCtx = createContext<LifeState>(emptyBoard());
-
-// ── presentational cell (shared by both backends) ──
-function Cell({
-  alive,
-  i,
-  onPaint,
-  pulse,
-  r,
-}: {
-  alive: boolean;
-  i: number;
-  onPaint: (i: number) => void;
-  pulse: boolean;
-  r: number;
-}) {
-  return (
-    <div
-      className={alive ? "ri-cell ri-on" : "ri-cell"}
-      data-r={r}
-      onPointerDown={(e) => {
-        e.preventDefault();
-        onPaint(i);
-      }}
-      onPointerEnter={(e) => {
-        if (e.buttons === 1) onPaint(i);
-      }}
-    >
-      {/* keyed remount replays the pulse animation on every render */}
-      {pulse && <span className="ri-pulse" key={r} />}
-    </div>
-  );
-}
-
-// ── re-reduced cell: subscribes to ONE cell signal → re-renders only on flip ──
-function RRCell({
-  store,
-  i,
-  stats,
-  onPaint,
-  pulse,
-}: {
-  store: LifeStore;
-  i: number;
-  stats: Stats;
-  onPaint: (i: number) => void;
-  pulse: boolean;
-}) {
-  const v = useSelect(store, (s) => s[cellKey(i)].value);
-  stats.renders += 1;
-  const r = useRef(0);
-  r.current += 1;
-  return (
-    <Cell alive={v === 1} i={i} onPaint={onPaint} pulse={pulse} r={r.current} />
-  );
-}
-
-const RRBoard = memo(function RRBoard({
-  store,
-  stats,
-  onPaint,
-  pulse,
-}: {
-  store: LifeStore;
-  stats: Stats;
-  onPaint: (i: number) => void;
-  pulse: boolean;
-}) {
-  return (
-    <div className="ri-grid" style={gridStyle}>
-      {CELL_KEYS.map((_, i) => (
-        <RRCell
-          // biome-ignore lint/suspicious/noArrayIndexKey: cells are a fixed-length grid
-          key={i}
-          store={store}
-          i={i}
-          stats={stats}
-          onPaint={onPaint}
-          pulse={pulse}
-        />
-      ))}
-    </div>
-  );
-});
-
-// ── Context cell: reads the whole board → re-renders on ANY change (broadcast) ──
-function CtxCell({
-  i,
-  stats,
-  onPaint,
-  pulse,
-}: {
-  i: number;
-  stats: Stats;
-  onPaint: (i: number) => void;
-  pulse: boolean;
-}) {
-  const board = useContext(LifeCtx);
-  stats.renders += 1;
-  const r = useRef(0);
-  r.current += 1;
-  return (
-    <Cell
-      alive={board[cellKey(i)] === 1}
-      i={i}
-      onPaint={onPaint}
-      pulse={pulse}
-      r={r.current}
-    />
-  );
-}
-
-const CtxBoard = memo(function CtxBoard({
-  stats,
-  onPaint,
-  pulse,
-}: {
-  stats: Stats;
-  onPaint: (i: number) => void;
-  pulse: boolean;
-}) {
-  return (
-    <div className="ri-grid" style={gridStyle}>
-      {CELL_KEYS.map((_, i) => (
-        <CtxCell
-          // biome-ignore lint/suspicious/noArrayIndexKey: cells are a fixed-length grid
-          key={i}
-          i={i}
-          stats={stats}
-          onPaint={onPaint}
-          pulse={pulse}
-        />
-      ))}
-    </div>
-  );
-});
-
-function Panel({
-  title,
-  subtitle,
-  renders,
-  tone,
-  badgeTestId,
-  children,
-}: {
-  title: string;
-  subtitle: string;
-  renders: number;
-  tone: "good" | "bad";
-  badgeTestId: string;
-  children: ReactNode;
-}) {
-  return (
-    <div className="ri-panel">
-      <div className="ri-panel-head">
-        <strong>{title}</strong>
-        <span className={`ri-badge ri-${tone}`} data-testid={badgeTestId}>
-          {renders.toLocaleString()} cell re-renders
-        </span>
-      </div>
-      <p className="ri-sub">{subtitle}</p>
-      {children}
-    </div>
-  );
-}
-
 /**
- * Render Inspector — Conway's Game of Life on a {ROWS}×{COLS} grid of DOM nodes,
- * run on two backends at once from one set of controls. Watch the cell-re-render
+ * Render Inspector — Conway's Game of Life on a 30×30 grid of DOM nodes, run on
+ * two backends at once from one set of controls. Watch the cell-re-render
  * counters and the render pulses: re-reduced updates only flipped cells; the
  * Context backend re-renders the whole grid every tick.
+ *
+ * This component is just orchestration — board stores, the run loop, and the
+ * derived metrics. The control bar, the two boards, the metrics readout, and the
+ * per-backend measurement plumbing each live in their own sibling module.
  */
 export function RenderInspector() {
   const rrRc = useRef<RecomputeCounter>({ count: 0 });
@@ -214,42 +42,21 @@ export function RenderInspector() {
     emptyBoard,
   );
 
-  const rrStats = useRef<Stats>({ renders: 0 });
-  const ctxStats = useRef<Stats>({ renders: 0 });
+  const rr = useBackend();
+  const ctx = useBackend();
   const [, force] = useReducer((n: number) => n + 1, 0);
 
   const [gen, setGen] = useState(0);
-  const [running, setRunning] = useState(false);
-  const [raf, setRaf] = useState(false);
+  const [mode, setMode] = useState<RunMode>("idle");
   const [speed, setSpeed] = useState(6);
   const [pulse, setPulse] = useState(true);
-  // Which backend(s) the run loop drives. Isolate one to measure its true
-  // sustained FPS without the other contending for the same frame budget.
-  const [active, setActive] = useState<"both" | "rr" | "ctx">("both");
+  // Isolate one backend to measure its true sustained FPS without the other
+  // contending for the same frame budget.
+  const [active, setActive] = useState<Active>("both");
   const runRR = active !== "ctx";
   const runCtx = active !== "rr";
 
-  // Per-board render time, measured independently so the slow Context board
-  // doesn't just gate one shared frame number. (React fires onRender only in
-  // dev / profiling builds — production reads 0, shown as "—".)
-  const rrProf = useRef({ ms: 0, commits: 0 });
-  const ctxProf = useRef({ ms: 0, commits: 0 });
   const fps = useRef({ frames: 0, since: 0, value: 0 });
-
-  const onRRRender = useCallback<ProfilerOnRenderCallback>(
-    (_id, _p, actual) => {
-      rrProf.current.ms += actual;
-      rrProf.current.commits += 1;
-    },
-    [],
-  );
-  const onCtxRender = useCallback<ProfilerOnRenderCallback>(
-    (_id, _p, actual) => {
-      ctxProf.current.ms += actual;
-      ctxProf.current.commits += 1;
-    },
-    [],
-  );
 
   const paint = useCallback(
     (i: number) => {
@@ -259,11 +66,13 @@ export function RenderInspector() {
     [rrStore],
   );
 
-  const step = useCallback(() => {
-    if (active !== "ctx") rrStore.actions.tick();
-    if (active !== "rr") ctxDispatch({ type: "tick" });
+  // The single source of truth for a tick — shared by the fixed-rate loop, the
+  // max-rate loop, and the Step button so they can't drift apart.
+  const advance = useCallback(() => {
+    if (runRR) rrStore.actions.tick();
+    if (runCtx) ctxDispatch({ type: "tick" });
     setGen((g) => g + 1);
-  }, [rrStore, active]);
+  }, [runRR, runCtx, rrStore]);
 
   const randomize = useCallback(() => {
     const board = randomBoard(0.3, Math.random);
@@ -273,32 +82,30 @@ export function RenderInspector() {
   }, [rrStore]);
 
   const clear = useCallback(() => {
-    setRunning(false);
+    setMode("idle");
     rrStore.actions.clear();
     ctxDispatch({ type: "clear" });
     setGen(0);
   }, [rrStore]);
 
   const resetStats = useCallback(() => {
-    rrStats.current.renders = 0;
-    ctxStats.current.renders = 0;
+    resetBackend(rr);
+    resetBackend(ctx);
     rrRc.current.count = 0;
-    rrProf.current = { ms: 0, commits: 0 };
-    ctxProf.current = { ms: 0, commits: 0 };
     fps.current = { frames: 0, since: 0, value: 0 };
     force();
-  }, []);
+  }, [rr, ctx]);
 
   // fixed-rate run loop (Play)
   useEffect(() => {
-    if (!running || raf) return;
-    const id = setInterval(step, Math.max(33, Math.round(1000 / speed)));
+    if (mode !== "play") return;
+    const id = setInterval(advance, Math.max(33, Math.round(1000 / speed)));
     return () => clearInterval(id);
-  }, [running, raf, speed, step]);
+  }, [mode, speed, advance]);
 
   // max-rate run loop (rAF) — ticks as fast as the frame budget allows
   useEffect(() => {
-    if (!raf) return;
+    if (mode !== "max") return;
     let id = 0;
     const loop = (t: number) => {
       const f = fps.current;
@@ -309,20 +116,19 @@ export function RenderInspector() {
         f.frames = 0;
         f.since = t;
       }
-      if (active !== "ctx") rrStore.actions.tick();
-      if (active !== "rr") ctxDispatch({ type: "tick" });
-      setGen((g) => g + 1);
+      advance();
       id = requestAnimationFrame(loop);
     };
     id = requestAnimationFrame(loop);
     return () => cancelAnimationFrame(id);
-  }, [raf, rrStore, active]);
+  }, [mode, advance]);
 
   // measurements are only meaningful within one run mode — reset on change
+  const maxMode = mode === "max";
   // biome-ignore lint/correctness/useExhaustiveDependencies: resetStats is stable
   useEffect(() => {
     resetStats();
-  }, [active, raf]);
+  }, [active, maxMode]);
 
   // seed a board on mount
   useEffect(() => {
@@ -332,111 +138,41 @@ export function RenderInspector() {
   const rrPop = rrStore.$derived.population.peek();
   const ctxPop = population(ctxBoard);
 
-  // Only report a backend's timing while it's actually being driven — a paused
-  // board's last (near-zero) commit would otherwise divide into a junk FPS.
-  const rrMs =
-    runRR && rrProf.current.commits
-      ? rrProf.current.ms / rrProf.current.commits
-      : 0;
-  const ctxMs =
-    runCtx && ctxProf.current.commits
-      ? ctxProf.current.ms / ctxProf.current.commits
-      : 0;
+  const rrMs = perTick(rr.prof.current, runRR);
+  const ctxMs = perTick(ctx.prof.current, runCtx);
   const rrFps = rrMs ? Math.round(1000 / rrMs) : 0;
   const ctxFps = ctxMs ? Math.round(1000 / ctxMs) : 0;
 
   return (
     <div className="ri not-prose">
-      <div className="ri-controls">
-        <span className="ri-group">
-          <button
-            type="button"
-            className="ri-btn ri-primary"
-            onClick={() => setRunning((r) => !r)}
-            disabled={raf}
-          >
-            {running ? "⏸ Pause" : "▶ Play"}
-          </button>
-          <button
-            type="button"
-            className={raf ? "ri-btn ri-primary" : "ri-btn"}
-            onClick={() => setRaf((v) => !v)}
-            disabled={running}
-          >
-            {raf ? "⏹ Stop max" : "⚡ Max (rAF)"}
-          </button>
-          <button
-            type="button"
-            className="ri-btn"
-            onClick={step}
-            disabled={running || raf}
-          >
-            ⏭ Step
-          </button>
-        </span>
-
-        <span className="ri-group">
-          <button type="button" className="ri-btn" onClick={randomize}>
-            🎲 Randomize
-          </button>
-          <button type="button" className="ri-btn" onClick={clear}>
-            ✕ Clear
-          </button>
-          <button type="button" className="ri-btn" onClick={resetStats}>
-            ↺ Reset counts
-          </button>
-        </span>
-
-        <span className="ri-seg">
-          {(["both", "rr", "ctx"] as const).map((m) => (
-            <button
-              key={m}
-              type="button"
-              className={active === m ? "ri-btn ri-on-seg" : "ri-btn"}
-              onClick={() => setActive(m)}
-            >
-              {m === "both" ? "Both" : m === "rr" ? "rr only" : "ctx only"}
-            </button>
-          ))}
-        </span>
-
-        <span className="ri-group">
-          <label className="ri-field">
-            Speed
-            <input
-              type="range"
-              min={1}
-              max={15}
-              value={speed}
-              onChange={(e) => setSpeed(Number(e.target.value))}
-            />
-            <span className="ri-mono">{speed}/s</span>
-          </label>
-          <label className="ri-field">
-            <input
-              type="checkbox"
-              checked={pulse}
-              onChange={(e) => setPulse(e.target.checked)}
-            />
-            Render pulse
-          </label>
-        </span>
-      </div>
-      <p className="ri-draw-hint">✎ Drag on either grid to draw cells.</p>
+      <Controls
+        mode={mode}
+        setMode={setMode}
+        active={active}
+        setActive={setActive}
+        speed={speed}
+        setSpeed={setSpeed}
+        pulse={pulse}
+        setPulse={setPulse}
+        onStep={advance}
+        onRandomize={randomize}
+        onClear={clear}
+        onResetStats={resetStats}
+      />
 
       <div className="ri-boards">
         <div className={runRR ? "ri-wrap" : "ri-wrap ri-idle"}>
           <Panel
             title="re-reduced"
             subtitle="one signal per cell — only flipped cells re-render"
-            renders={rrStats.current.renders}
+            renders={rr.stats.current.renders}
             tone="good"
             badgeTestId="rr-renders"
           >
-            <Profiler id="rr" onRender={onRRRender}>
+            <Profiler id="rr" onRender={rr.onRender}>
               <RRBoard
                 store={rrStore}
-                stats={rrStats.current}
+                stats={rr.stats.current}
                 onPaint={paint}
                 pulse={pulse}
               />
@@ -448,14 +184,14 @@ export function RenderInspector() {
           <Panel
             title="useReducer + Context"
             subtitle="one state object — every cell re-renders each tick"
-            renders={ctxStats.current.renders}
+            renders={ctx.stats.current.renders}
             tone="bad"
             badgeTestId="ctx-renders"
           >
-            <Profiler id="ctx" onRender={onCtxRender}>
+            <Profiler id="ctx" onRender={ctx.onRender}>
               <LifeCtx.Provider value={ctxBoard}>
                 <CtxBoard
-                  stats={ctxStats.current}
+                  stats={ctx.stats.current}
                   onPaint={paint}
                   pulse={pulse}
                 />
@@ -465,103 +201,24 @@ export function RenderInspector() {
         </div>
       </div>
 
-      <dl className="ri-stats">
-        <div className="ri-feat">
-          <dt>
-            cell re-renders{" "}
-            <span className="ri-dim">(Context vs re-reduced)</span>
-          </dt>
-          <dd className="ri-mono">
-            {rrStats.current.renders > 0
-              ? `${(ctxStats.current.renders / rrStats.current.renders).toFixed(1)}×`
-              : "—"}
-          </dd>
-          <dt className="ri-dim">
-            fewer with re-reduced ·{" "}
-            <span className="ri-rr">
-              {rrStats.current.renders.toLocaleString()}
-            </span>{" "}
-            vs{" "}
-            <span className="ri-ctx">
-              {ctxStats.current.renders.toLocaleString()}
-            </span>
-          </dt>
-        </div>
-        <div className="ri-wide">
-          <dt>
-            renders / sec <span className="ri-dim">(per backend)</span>
-          </dt>
-          <dd className="ri-mono">
-            <span className="ri-rr">{rrFps || "—"}</span> /{" "}
-            <span className="ri-ctx">{ctxFps || "—"}</span>
-          </dd>
-        </div>
-        <div className="ri-wide">
-          <dt>
-            render time / tick <span className="ri-dim">(ms · rr / ctx)</span>
-          </dt>
-          <dd className="ri-mono">
-            <span className="ri-rr">{rrMs ? rrMs.toFixed(2) : "—"}</span> /{" "}
-            <span className="ri-ctx">{ctxMs ? ctxMs.toFixed(2) : "—"}</span>
-          </dd>
-        </div>
-        <div>
-          <dt>
-            loop FPS <span className="ri-dim">(rAF, {active})</span>
-          </dt>
-          <dd className="ri-mono">
-            {raf ? Math.round(fps.current.value) : "—"}
-          </dd>
-        </div>
-        <div>
-          <dt>
-            population <span className="ri-dim">(rr / ctx)</span>
-          </dt>
-          <dd className="ri-mono">
-            <span className="ri-rr">{rrPop}</span> /{" "}
-            <span className="ri-ctx">{ctxPop}</span>
-          </dd>
-        </div>
-        <div>
-          <dt>
-            <code>population</code> recomputes{" "}
-            <span className="ri-dim">(rr, memoized)</span>
-          </dt>
-          <dd className="ri-mono">{rrRc.current.count}</dd>
-        </div>
-        <div>
-          <dt>Generation</dt>
-          <dd className="ri-mono">{gen}</dd>
-        </div>
-      </dl>
-
-      {!raf && rrFps === 0 && ctxFps === 0 && (
-        <p className="ri-hint">
-          Timing populates once it runs. For a clean per-backend FPS, switch to{" "}
-          <strong>rr only</strong> / <strong>ctx only</strong> and hit{" "}
-          <strong>⚡ Max (rAF)</strong> so the other board isn't sharing the
-          frame.
-        </p>
-      )}
-
-      <p className="ri-note">
-        Both backends share the same board and controls — the <em>only</em>{" "}
-        difference is how each subscribes. Watch the pulse: re-reduced lights up
-        just the cells that flipped; Context strobes the whole grid every tick.
-        The re-reduced tick is still O(cells) in JS (snapshot + diff — see the
-        benchmarks), but it avoids the DOM commit that makes the Context board
-        jank at speed.
-      </p>
-      <p className="ri-note">
-        <strong>Reading the FPS fairly.</strong> <em>render ms / tick</em> is
-        per-backend and stays clean even with both running — React renders each
-        board's subtree sequentially and the <code>Profiler</code> times each on
-        its own. <em>loop FPS</em> is the shared frame budget, so it reflects
-        whatever is active: to read a backend's <em>true</em> sustained FPS,
-        switch <em>Both → rr only / ctx only</em> so the other isn't contending.
-        (Render timing needs React's dev/profiling build; a production bundle
-        shows “—”.)
-      </p>
+      <StatsPanel
+        rr={{
+          renders: rr.stats.current.renders,
+          fps: rrFps,
+          ms: rrMs,
+          pop: rrPop,
+        }}
+        ctx={{
+          renders: ctx.stats.current.renders,
+          fps: ctxFps,
+          ms: ctxMs,
+          pop: ctxPop,
+        }}
+        loopFps={maxMode ? Math.round(fps.current.value) : null}
+        active={active}
+        popRecomputes={rrRc.current.count}
+        gen={gen}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Thermo-nuclear code-quality pass on the render-inspector demo + bench.

## What
- `life.tsx` **567 → 224 lines**: the ~360-line god component split into focused sibling modules — `life-controls`, `life-boards`, `life-stats`, `life-metrics`.
- **Mode union**: collapse the mutually-exclusive `running`/`raf` booleans into one `RunMode = idle | play | max`, deleting the hand-written cross-`disabled` guards.
- **Shared `advance()`**: one tick source for the fixed-rate loop, rAF loop, and Step — fixes a latent drift bug (the rAF loop previously re-inlined the tick logic).
- **Dedup**: per-backend tally/Profiler plumbing behind `useBackend` + `useRenderTally`.
- **Types**: board is `Record<string, 0 | 1>`; shared `BenchState` extracted so the two bench probes stop redeclaring it.

## Verify
demos typecheck ✓ · bench typecheck ✓ · render-inspector example test ✓ · biome ✓

Public export (`RenderInspector`) and `life.css` unchanged.