### PR TITLE
feat(docs): add re-reduced logo icon + favicon

### DIFF
--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -11,3 +11,8 @@ html > body[data-scroll-locked] {
   margin-right: 0px !important;
   --removed-body-scroll-bar-size: 0px !important;
 }
+
+/* Logo nodes: deep indigo has no contrast on the dark nav — lighten on dark. */
+.dark .rr-logo-node {
+  fill: #9d9aea;
+}

--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -11,8 +11,3 @@ html > body[data-scroll-locked] {
   margin-right: 0px !important;
   --removed-body-scroll-bar-size: 0px !important;
 }
-
-/* Logo nodes: deep indigo has no contrast on the dark nav — lighten on dark. */
-.dark .rr-logo-node {
-  fill: #9d9aea;
-}

--- a/apps/docs/app/icon.svg
+++ b/apps/docs/app/icon.svg
@@ -1,0 +1,25 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="re-reduced">
+  <title>re-reduced</title>
+  <!-- coral edge segments (gapped, between the nodes) -->
+  <g stroke="#EF5C4C" stroke-width="3" stroke-linecap="round">
+    <line x1="36.76" y1="10.75" x2="48.02" y2="17.25" />
+    <line x1="52.78" y1="25.5" x2="52.78" y2="38.5" />
+    <line x1="48.02" y1="46.75" x2="36.76" y2="53.25" />
+    <line x1="27.24" y1="53.25" x2="15.98" y2="46.75" />
+    <line x1="11.22" y1="38.5" x2="11.22" y2="25.5" />
+    <line x1="15.98" y1="17.25" x2="27.24" y2="10.75" />
+  </g>
+  <!-- indigo nodes at the hexagon vertices -->
+  <g fill="#2E2A7C">
+    <circle cx="32" cy="8" r="4.5" />
+    <circle cx="52.78" cy="20" r="4.5" />
+    <circle cx="52.78" cy="44" r="4.5" />
+    <circle cx="32" cy="56" r="4.5" />
+    <circle cx="11.22" cy="44" r="4.5" />
+    <circle cx="11.22" cy="20" r="4.5" />
+  </g>
+  <!-- isometric coral cube at the center -->
+  <polygon points="32,23 41,27.5 32,32 23,27.5" fill="#F2705E" />
+  <polygon points="23,27.5 32,32 32,41 23,36.5" fill="#EC5747" />
+  <polygon points="41,27.5 32,32 32,41 41,36.5" fill="#D5402E" />
+</svg>

--- a/apps/docs/app/icon.svg
+++ b/apps/docs/app/icon.svg
@@ -1,5 +1,10 @@
 <svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="re-reduced">
   <title>re-reduced</title>
+  <!-- deep indigo has no contrast on dark chrome — lighten the nodes there -->
+  <style>
+    .rr-logo-node { fill: #2E2A7C; }
+    @media (prefers-color-scheme: dark) { .rr-logo-node { fill: #9D9AEA; } }
+  </style>
   <!-- coral edge segments (gapped, between the nodes) -->
   <g stroke="#EF5C4C" stroke-width="3" stroke-linecap="round">
     <line x1="36.76" y1="10.75" x2="48.02" y2="17.25" />
@@ -10,7 +15,7 @@
     <line x1="15.98" y1="17.25" x2="27.24" y2="10.75" />
   </g>
   <!-- indigo nodes at the hexagon vertices -->
-  <g fill="#2E2A7C">
+  <g class="rr-logo-node" fill="#2E2A7C">
     <circle cx="32" cy="8" r="4.5" />
     <circle cx="52.78" cy="20" r="4.5" />
     <circle cx="52.78" cy="44" r="4.5" />

--- a/apps/docs/components/logo.tsx
+++ b/apps/docs/components/logo.tsx
@@ -1,0 +1,37 @@
+/**
+ * The re-reduced mark — indigo node-hexagon around a coral isometric cube.
+ * Inlined (not an <img>) so it renders crisp at any size and ignores basePath.
+ * `currentColor` is not used: the brand colors are fixed in both themes.
+ */
+export function Logo({ size = 22 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 64 64"
+      fill="none"
+      role="img"
+      aria-label="re-reduced"
+    >
+      <g stroke="#EF5C4C" strokeWidth="3" strokeLinecap="round">
+        <line x1="36.76" y1="10.75" x2="48.02" y2="17.25" />
+        <line x1="52.78" y1="25.5" x2="52.78" y2="38.5" />
+        <line x1="48.02" y1="46.75" x2="36.76" y2="53.25" />
+        <line x1="27.24" y1="53.25" x2="15.98" y2="46.75" />
+        <line x1="11.22" y1="38.5" x2="11.22" y2="25.5" />
+        <line x1="15.98" y1="17.25" x2="27.24" y2="10.75" />
+      </g>
+      <g fill="#2E2A7C">
+        <circle cx="32" cy="8" r="4.5" />
+        <circle cx="52.78" cy="20" r="4.5" />
+        <circle cx="52.78" cy="44" r="4.5" />
+        <circle cx="32" cy="56" r="4.5" />
+        <circle cx="11.22" cy="44" r="4.5" />
+        <circle cx="11.22" cy="20" r="4.5" />
+      </g>
+      <polygon points="32,23 41,27.5 32,32 23,27.5" fill="#F2705E" />
+      <polygon points="23,27.5 32,32 32,41 23,36.5" fill="#EC5747" />
+      <polygon points="41,27.5 32,32 32,41 41,36.5" fill="#D5402E" />
+    </svg>
+  );
+}

--- a/apps/docs/components/logo.tsx
+++ b/apps/docs/components/logo.tsx
@@ -1,7 +1,8 @@
 /**
  * The re-reduced mark — indigo node-hexagon around a coral isometric cube.
  * Inlined (not an <img>) so it renders crisp at any size and ignores basePath.
- * `currentColor` is not used: the brand colors are fixed in both themes.
+ * Nodes lighten on dark via the `.rr-logo-node` rule in global.css (the deep
+ * indigo has no contrast on a dark nav); the coral edges + cube read on both.
  */
 export function Logo({ size = 22 }: { size?: number }) {
   return (
@@ -21,7 +22,7 @@ export function Logo({ size = 22 }: { size?: number }) {
         <line x1="11.22" y1="38.5" x2="11.22" y2="25.5" />
         <line x1="15.98" y1="17.25" x2="27.24" y2="10.75" />
       </g>
-      <g fill="#2E2A7C">
+      <g className="rr-logo-node" fill="#2E2A7C">
         <circle cx="32" cy="8" r="4.5" />
         <circle cx="52.78" cy="20" r="4.5" />
         <circle cx="52.78" cy="44" r="4.5" />

--- a/apps/docs/components/logo.tsx
+++ b/apps/docs/components/logo.tsx
@@ -1,8 +1,10 @@
 /**
- * The re-reduced mark — indigo node-hexagon around a coral isometric cube.
+ * The re-reduced mark — node-hexagon around a coral isometric cube.
  * Inlined (not an <img>) so it renders crisp at any size and ignores basePath.
- * Nodes lighten on dark via the `.rr-logo-node` rule in global.css (the deep
- * indigo has no contrast on a dark nav); the coral edges + cube read on both.
+ * Nodes use `currentColor` so they track the nav's foreground (legible in both
+ * themes — deep indigo had no contrast on the dark nav); the coral edges + cube
+ * are brand accents that read on both. The standalone favicon keeps fixed brand
+ * colors via a prefers-color-scheme query (no text color to inherit there).
  */
 export function Logo({ size = 22 }: { size?: number }) {
   return (
@@ -22,7 +24,7 @@ export function Logo({ size = 22 }: { size?: number }) {
         <line x1="11.22" y1="38.5" x2="11.22" y2="25.5" />
         <line x1="15.98" y1="17.25" x2="27.24" y2="10.75" />
       </g>
-      <g className="rr-logo-node" fill="#2E2A7C">
+      <g fill="currentColor">
         <circle cx="32" cy="8" r="4.5" />
         <circle cx="52.78" cy="20" r="4.5" />
         <circle cx="52.78" cy="44" r="4.5" />

--- a/apps/docs/lib/layout.shared.tsx
+++ b/apps/docs/lib/layout.shared.tsx
@@ -1,11 +1,16 @@
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
+import { Logo } from '@/components/logo';
 import { appName, gitConfig } from './shared';
 
 export function baseOptions(): BaseLayoutProps {
   return {
     nav: {
-      // JSX supported
-      title: appName,
+      title: (
+        <span className="inline-flex items-center gap-2 font-semibold">
+          <Logo />
+          {appName}
+        </span>
+      ),
     },
     githubUrl: `https://github.com/${gitConfig.user}/${gitConfig.repo}`,
   };

--- a/assets/logo-icon.svg
+++ b/assets/logo-icon.svg
@@ -1,0 +1,25 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="re-reduced">
+  <title>re-reduced</title>
+  <!-- coral edge segments (gapped, between the nodes) -->
+  <g stroke="#EF5C4C" stroke-width="3" stroke-linecap="round">
+    <line x1="36.76" y1="10.75" x2="48.02" y2="17.25" />
+    <line x1="52.78" y1="25.5" x2="52.78" y2="38.5" />
+    <line x1="48.02" y1="46.75" x2="36.76" y2="53.25" />
+    <line x1="27.24" y1="53.25" x2="15.98" y2="46.75" />
+    <line x1="11.22" y1="38.5" x2="11.22" y2="25.5" />
+    <line x1="15.98" y1="17.25" x2="27.24" y2="10.75" />
+  </g>
+  <!-- indigo nodes at the hexagon vertices -->
+  <g fill="#2E2A7C">
+    <circle cx="32" cy="8" r="4.5" />
+    <circle cx="52.78" cy="20" r="4.5" />
+    <circle cx="52.78" cy="44" r="4.5" />
+    <circle cx="32" cy="56" r="4.5" />
+    <circle cx="11.22" cy="44" r="4.5" />
+    <circle cx="11.22" cy="20" r="4.5" />
+  </g>
+  <!-- isometric coral cube at the center -->
+  <polygon points="32,23 41,27.5 32,32 23,27.5" fill="#F2705E" />
+  <polygon points="23,27.5 32,32 32,41 23,36.5" fill="#EC5747" />
+  <polygon points="41,27.5 32,32 32,41 41,36.5" fill="#D5402E" />
+</svg>

--- a/assets/logo-icon.svg
+++ b/assets/logo-icon.svg
@@ -1,5 +1,10 @@
 <svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="re-reduced">
   <title>re-reduced</title>
+  <!-- deep indigo has no contrast on dark chrome — lighten the nodes there -->
+  <style>
+    .rr-logo-node { fill: #2E2A7C; }
+    @media (prefers-color-scheme: dark) { .rr-logo-node { fill: #9D9AEA; } }
+  </style>
   <!-- coral edge segments (gapped, between the nodes) -->
   <g stroke="#EF5C4C" stroke-width="3" stroke-linecap="round">
     <line x1="36.76" y1="10.75" x2="48.02" y2="17.25" />
@@ -10,7 +15,7 @@
     <line x1="15.98" y1="17.25" x2="27.24" y2="10.75" />
   </g>
   <!-- indigo nodes at the hexagon vertices -->
-  <g fill="#2E2A7C">
+  <g class="rr-logo-node" fill="#2E2A7C">
     <circle cx="32" cy="8" r="4.5" />
     <circle cx="52.78" cy="20" r="4.5" />
     <circle cx="52.78" cy="44" r="4.5" />


### PR DESCRIPTION
Standalone icon mark derived from `assets/logo.png` — the indigo node-hexagon around a coral isometric cube, no wordmark.

- **`assets/logo-icon.svg`** — reusable mark (64×64, brand colors baked)
- **`apps/docs/app/icon.svg`** — Next auto-detects it as the favicon (emitted at `/icon.svg`)
- **`Logo`** component (inlined SVG, basePath-safe) now sits in the docs nav title

Build ✓ (favicon route emitted, present in static export).