### PR TITLE
feat(core): O(1) dispatch via state mirror + partial returns

### DIFF
--- a/apps/docs/components/bench.tsx
+++ b/apps/docs/components/bench.tsx
@@ -124,9 +124,9 @@ export function BenchScaling() {
         </text>
       </svg>
       <figcaption className="mt-1 text-xs text-fd-muted-foreground">
-        Bumping one field in an N-field container. re-reduced is O(fields)
-        (snapshot + diff); zustand stays near-flat. Still nanoseconds at realistic
-        sizes.
+        Bumping one field in an N-field container. re-reduced writes only the
+        changed key, so it stays flat; zustand allocates a merged state object per{" "}
+        <code>set</code>, so it grows with field count.
       </figcaption>
       <NumberTable
         head={["Fields", "re-reduced", "zustand"]}

--- a/apps/docs/content/docs/benchmarks.mdx
+++ b/apps/docs/content/docs/benchmarks.mdx
@@ -51,20 +51,23 @@ rates it's far below the noise floor.
 
 ### How dispatch scales with state size
 
-Each dispatch snapshots current state (to hand the reducer a plain object) and
-shallow-diffs the result, so cost grows with field count:
+A handler returns only the keys it changes; the store writes exactly those
+signals and keeps a plain-object mirror in lockstep, so it never peeks the whole
+container per dispatch ([ADR-0010](https://github.com/alanrsoares/re-reduced/blob/main/docs/adr/0010-action-handlers-merge-returned-keys.md)).
+Bumping **one** field in an `N`-field container:
 
 <BenchScaling />
 
-re-reduced dispatch is **O(fields)**; Zustand stays near-flat because it holds a
-single state object and merges shallow patches without a per-field diff. This is
-a deliberate tradeoff, not a missing optimisation: pure `(state) => state`
-reducers (you spread the old state) plus per-field signals (what enables the
-render bail-out above) together mean each dispatch materialises the whole state.
-We tried a lazy-proxy state to dodge the snapshot — it made the common spread
-reducer **~7× slower**, because spreading enumerates every field through the
-proxy traps. The snapshot is the cheaper path. Reach for re-reduced for the
-render granularity, not to win a dispatch microbenchmark.
+re-reduced dispatch is **O(changed keys)** — flat regardless of container size.
+Zustand grows with field count here because each `set` allocates a fresh merged
+state object. The cost is to write a one-field handler as `(s) => ({ count:
+s.count + 1 })` — no spread; the returned keys are merged.
+
+> Earlier this curve ran the other way: handlers were typed to return the full
+> state, forcing a `...s` spread and an O(fields) snapshot + diff every dispatch.
+> The mirror plus partial returns removed both — without a lazy proxy (that was
+> tried and abandoned at ~7× slower, since spreads enumerate every field through
+> the proxy traps).
 
 ## Derivation reads
 
@@ -83,8 +86,8 @@ read far more often than its inputs change; skip it for trivial scalar math.
 
 - **Renders:** fine-grained by construction, on par with Zustand, ahead of
   Context-based reducers.
-- **Dispatch:** Zustand-class at small state; scales **O(fields)** because each
-  dispatch snapshots + diffs the whole state — the deliberate price of pure
-  reducers over per-field signals. Still nanoseconds at realistic sizes.
+- **Dispatch:** **O(changed keys)** — flat regardless of container size, because
+  handlers return only what changed and the store writes just those signals.
+  Zustand-class (or ahead) at small state; pulls ahead as the container grows.
 - **Derivations:** memoized — a large win above the crossover, a small loss
   below it. Use `derive` for non-trivial computed values read repeatedly.

--- a/apps/docs/content/docs/core-concepts.mdx
+++ b/apps/docs/content/docs/core-concepts.mdx
@@ -35,18 +35,24 @@ store.getState();   // glitch-free snapshot
 
 ## Actions are pure transitions
 
-Actions are `(state, payload) => state`. The `on` builder captures the payload
-type; an action whose handler ignores the payload is nullary.
+Actions are `(state, payload) => Partial<state>`. A handler returns **only the
+keys it changes** — they're merged into state, so there's no `...s` spread. The
+`on` builder captures the payload type; an action whose handler ignores the
+payload is nullary. `state` is read-only.
 
 ```ts
 actions: (on) => ({
-  filterChanged: on<Filter>((s, filter) => ({ ...s, filter })),
-  clear: on((s) => ({ ...s, items: [] })),
+  filterChanged: on<Filter>((_s, filter) => ({ filter })),
+  clear: on(() => ({ items: [] })),
 })
 
 store.actions.filterChanged("done"); // typed
 store.actions.clear();                // nullary
 ```
+
+Returning a subset merges; only changed signals are written, so dispatch stays
+**O(changed keys)** regardless of how many fields the container has (see the
+[benchmarks](/docs/benchmarks)). A spread still works — it's just unnecessary.
 
 Transitions **never throw and never return a `Result`**. Model a fallible
 transition by writing a discriminated-union error field into state, and expose
@@ -54,7 +60,7 @@ validity as a derivation the view reads before dispatching:
 
 ```ts
 submit: on((s) =>
-  s.draft.trim() === "" ? { ...s, error: "empty" } : { ...s, error: null, /* ... */ })
+  s.draft.trim() === "" ? { error: "empty" } : { error: null, /* ... */ })
 ```
 
 ## Derivations

--- a/apps/docs/lib/bench-results.json
+++ b/apps/docs/lib/bench-results.json
@@ -14,69 +14,69 @@
   "throughput": [
     {
       "label": "plain reducer",
-      "ns": 2.3
+      "ns": 2.4
     },
     {
       "label": "re-reduced",
-      "ns": 43.2
+      "ns": 33.5
     },
     {
       "label": "zustand",
-      "ns": 53.1
+      "ns": 56.5
     }
   ],
   "scaling": [
     {
       "fields": 1,
-      "reReduced": 54,
-      "zustand": 41.7
+      "reReduced": 35.4,
+      "zustand": 45.4
     },
     {
       "fields": 4,
-      "reReduced": 93.5,
-      "zustand": 62.6
+      "reReduced": 37.1,
+      "zustand": 59.6
     },
     {
       "fields": 16,
-      "reReduced": 334,
+      "reReduced": 37.2,
       "zustand": 139
     },
     {
       "fields": 64,
-      "reReduced": 982,
-      "zustand": 576
+      "reReduced": 35.5,
+      "zustand": 583
     }
   ],
   "derive": [
     {
       "work": 1,
-      "memoized": 10.6,
-      "recompute": 6.9
+      "memoized": 11.1,
+      "recompute": 7.3
     },
     {
       "work": 4,
-      "memoized": 11.5,
-      "recompute": 13.6
+      "memoized": 12.3,
+      "recompute": 14.2
     },
     {
       "work": 16,
-      "memoized": 11.2,
-      "recompute": 44.5
+      "memoized": 11.8,
+      "recompute": 47.7
     },
     {
       "work": 64,
-      "memoized": 11.1,
-      "recompute": 213
+      "memoized": 11.8,
+      "recompute": 228
     },
     {
       "work": 256,
-      "memoized": 11.1,
-      "recompute": 891
+      "memoized": 11.8,
+      "recompute": 963
     },
     {
       "work": 1024,
-      "memoized": 11.2,
-      "recompute": 3582
+      "memoized": 11.7,
+      "recompute": 3863
     }
   ]
 }

--- a/bench/src/capture.ts
+++ b/bench/src/capture.ts
@@ -69,7 +69,8 @@ for (const n of FIELDS) {
   const c = createContainer(
     defineContainer(`c${n}`, {
       state: mkFields(n),
-      actions: (on) => ({ inc: on((s) => ({ ...s, f0: s.f0 + 1 })) }),
+      // partial return — change one key, the rest are untouched (ADR-0010)
+      actions: (on) => ({ inc: on((s) => ({ f0: s.f0 + 1 })) }),
     }),
   );
   const z = createStore<Record<string, number>>(() => mkFields(n));

--- a/bench/src/scaling.ts
+++ b/bench/src/scaling.ts
@@ -34,7 +34,8 @@ summary(() => {
       const store = createContainer(
         defineContainer(`c${n}`, {
           state: mkState(n),
-          actions: (on) => ({ inc: on((s) => ({ ...s, f0: s.f0 + 1 })) }),
+          // partial return — change one key, the rest are untouched (ADR-0010)
+          actions: (on) => ({ inc: on((s) => ({ f0: s.f0 + 1 })) }),
         }),
       );
       yield () => {

--- a/docs/adr/0010-action-handlers-merge-returned-keys.md
+++ b/docs/adr/0010-action-handlers-merge-returned-keys.md
@@ -1,0 +1,42 @@
+# Action handlers return changed keys (merged), backed by a state mirror
+
+Action handlers return a `Partial<S>` of the keys that changed; the store merges
+them. A one-field update is `(s) => ({ count: s.count + 1 })` — no `...s` spread.
+`state` is passed read-only.
+
+## Context
+
+Handlers were typed `(state) => state`, which forced every handler to spread the
+whole state to satisfy the type, even to change one field. The commit path
+already only wrote the keys the handler returned (omitted keys were untouched),
+so the spread was pure overhead — and it made dispatch **O(fields)**: each
+dispatch peeked every signal to build the `prev` snapshot, the handler spread
+every field, and the diff walked every key. A one-field bump in a 64-field
+container cost ~1.4 µs; the dominant term was the eager snapshot, not the spread.
+
+A lazy state **proxy** was tried earlier and rejected (ADR rationale): it made
+spread handlers ~7× slower because spreading enumerates every field through the
+proxy traps.
+
+## Decision
+
+- Handler return type is `Partial<S>`; returned keys are merged into state.
+  Spreads still type-check (full `S` is assignable to `Partial<S>`), so this is
+  backward compatible — but the spread is now optional and discouraged.
+- `state` is typed `Readonly<S>`. The store hands the handler the **live mirror**
+  (not a copy), so mutating it would corrupt state; `Readonly<S>` makes that a
+  compile error at zero runtime cost.
+- The store keeps a plain-object **mirror** of state, updated in the same commit
+  loop that writes the signals. `getState()` clones it; dispatch reads it
+  directly. Neither peeks every signal per call.
+
+## Consequences
+
+- Dispatch is **O(changed keys)**, not O(fields): a one-field bump is flat (~60
+  ns) regardless of container size — measured ~23× faster at 64 fields, and now
+  flatter than Zustand instead of behind it.
+- This is a plain cached object, not a proxy, so it has none of the per-access
+  trap overhead that sank the lazy-proxy attempt.
+- Handlers must stay pure (never mutate `state`); `Readonly<S>` enforces it for
+  TypeScript callers. `getState()`'s clone keeps external mutation contained.
+- Supersedes the "dispatch is O(fields), a deliberate tradeoff" framing.

--- a/packages/core/src/container.ts
+++ b/packages/core/src/container.ts
@@ -23,10 +23,15 @@ import {
 // ── action registry ──
 /** Handler stored as a METHOD → bivariant params → satisfies the unknown-constraint. */
 export interface ActionSpec<S, P> {
-  reduce(state: S, payload: P): S;
+  /**
+   * Pure transition. Return the changed keys — they are merged into state, so a
+   * one-field update is `(s) => ({ count: s.count + 1 })`, no spread needed.
+   * `state` is read-only: it is the live store snapshot, not a copy (ADR-0010).
+   */
+  reduce(state: Readonly<S>, payload: P): Partial<S>;
 }
 export type OnBuilder<S> = <P = void>(
-  reduce: (state: S, payload: P) => S,
+  reduce: (state: Readonly<S>, payload: P) => Partial<S>,
 ) => ActionSpec<S, P>;
 
 type PayloadOf<Sp> = Sp extends ActionSpec<any, infer P> ? P : never;
@@ -183,13 +188,17 @@ export function createContainer<
   const cleanups: Array<() => void> = [];
 
   const $state = {} as Record<string, WriteSignal<unknown>>;
-  for (const key of Object.keys(initial)) $state[key] = signal(initial[key]);
+  // Plain-object shadow of state, kept in sync on every commit. Dispatch hands
+  // this to the reducer as `prev` and `getState()` clones it — so neither has to
+  // peek every signal per call, keeping dispatch O(changed) not O(fields).
+  const mirror = {} as Record<string, unknown>;
+  for (const key of Object.keys(initial)) {
+    $state[key] = signal(initial[key]);
+    mirror[key] = initial[key];
+  }
 
-  const snapshot = (): S => {
-    const out = {} as Record<string, unknown>;
-    for (const key of Object.keys($state)) out[key] = $state[key].peek();
-    return out as S;
-  };
+  // Clone on read so callers can't mutate the live mirror behind the signals.
+  const snapshot = (): S => ({ ...mirror }) as S;
 
   const interpreters = (opts?.interpreters ?? {}) as unknown as Record<
     string,
@@ -215,12 +224,19 @@ export function createContainer<
   const actions = {} as Record<string, (payload?: unknown) => void>;
   for (const key of Object.keys(specs)) {
     actions[key] = (payload?: unknown) => {
-      const prev = snapshot();
-      const next = specs[key].reduce(prev, payload) as Record<string, unknown>;
+      // Hand the live mirror as `prev` (read-only by contract — see ActionSpec).
+      // The reducer returns only the changed keys; write those signals + keep the
+      // mirror in lockstep so it stays an accurate shadow of state.
+      const next = specs[key].reduce(mirror as S, payload) as Record<
+        string,
+        unknown
+      >;
       batch(() => {
         for (const k of Object.keys(next)) {
-          if (!Object.is(next[k], (prev as Record<string, unknown>)[k]))
+          if (!Object.is(next[k], mirror[k])) {
             $state[k].value = next[k];
+            mirror[k] = next[k];
+          }
         }
       });
       for (const fn of actionListeners) fn(key, payload); // committed → notify (ADR-0005)

--- a/packages/core/test/mirror.spec.ts
+++ b/packages/core/test/mirror.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test";
+import { createContainer, defineContainer } from "../src/container";
+
+const make = () =>
+  createContainer(
+    defineContainer("t", {
+      state: { a: 0, b: 99, c: "x" },
+      actions: (on) => ({
+        // partial return — no spread; omitted keys must be retained
+        bumpA: on((s) => ({ a: s.a + 1 })),
+        setB: on<number>((_s, b) => ({ b })),
+        // full-replace style (spread) must still work
+        full: on((s) => ({ ...s, a: s.a + 10 })),
+      }),
+    }),
+  );
+
+describe("@re-reduced/core — state mirror + partial returns", () => {
+  it("merges partial returns, retaining omitted keys", () => {
+    const store = make();
+    store.actions.bumpA();
+    expect(store.getState()).toEqual({ a: 1, b: 99, c: "x" });
+    store.actions.setB(7);
+    expect(store.getState()).toEqual({ a: 1, b: 7, c: "x" });
+  });
+
+  it("keeps the mirror in sync across a sequence of dispatches", () => {
+    const store = make();
+    store.actions.bumpA();
+    store.actions.bumpA();
+    store.actions.full(); // a += 10 via spread
+    store.actions.setB(3);
+    expect(store.getState()).toEqual({ a: 12, b: 3, c: "x" });
+    // signals and the snapshot agree
+    expect(store.$state.a.peek()).toBe(12);
+    expect(store.$state.b.peek()).toBe(3);
+  });
+
+  it("getState() returns a clone — mutating it can't corrupt the store", () => {
+    const store = make();
+    const snap = store.getState();
+    (snap as { a: number }).a = 999;
+    expect(store.getState().a).toBe(0);
+    expect(store.$state.a.peek()).toBe(0);
+  });
+
+  it("only writes signals for keys that actually changed", () => {
+    const store = make();
+    let bWrites = 0;
+    store.$state.b.subscribe(() => {
+      bWrites += 1;
+    });
+    bWrites = 0; // ignore the immediate subscribe call
+    store.actions.bumpA(); // touches a, not b
+    expect(bWrites).toBe(0);
+  });
+});

--- a/packages/demos/src/life-store.ts
+++ b/packages/demos/src/life-store.ts
@@ -81,10 +81,8 @@ export const defineLife = (rc: RecomputeCounter) =>
   defineContainer("life", {
     state: emptyBoard(),
     actions: (on) => ({
-      setCell: on((s, p: { i: number; v: Cell }) => ({
-        ...s,
-        [cellKey(p.i)]: p.v,
-      })),
+      // partial return — one cell flips, the other ~899 are untouched (ADR-0010)
+      setCell: on((_s, p: { i: number; v: Cell }) => ({ [cellKey(p.i)]: p.v })),
       tick: on((s) => nextGeneration(s)),
       load: on((_s, board: LifeState) => board),
       clear: on(() => emptyBoard()),

--- a/packages/demos/src/todos.ts
+++ b/packages/demos/src/todos.ts
@@ -39,14 +39,15 @@ export const todos = defineContainer("todos", {
     status: "idle" as Status,
     error: null as string | null,
   },
+  // Handlers return only the keys that change — they're merged into state
+  // (ADR-0010), so no `...s` spread. `s` is read-only.
   actions: (on) => ({
-    draftChanged: on<string>((s, draft) => ({ ...s, draft, error: null })),
-    filterChanged: on<Filter>((s, filter) => ({ ...s, filter })),
+    draftChanged: on<string>((_s, draft) => ({ draft, error: null })),
+    filterChanged: on<Filter>((_s, filter) => ({ filter })),
     submit: on((s) =>
       s.draft.trim().length === 0
-        ? { ...s, error: "Title can't be empty" }
+        ? { error: "Title can't be empty" }
         : {
-            ...s,
             items: [
               { id: makeId(), title: s.draft.trim(), done: false },
               ...s.items,
@@ -55,21 +56,14 @@ export const todos = defineContainer("todos", {
           },
     ),
     toggled: on<{ id: string }>((s, { id }) => ({
-      ...s,
       items: s.items.map((t) => (t.id === id ? { ...t, done: !t.done } : t)),
     })),
     removed: on<{ id: string }>((s, { id }) => ({
-      ...s,
       items: s.items.filter((t) => t.id !== id),
     })),
-    load: on((s) => ({ ...s, status: "loading" as Status })),
-    loaded: on<Todo[]>((s, items) => ({
-      ...s,
-      items,
-      status: "ready" as Status,
-    })),
-    loadFailed: on<string>((s, error) => ({
-      ...s,
+    load: on(() => ({ status: "loading" as Status })),
+    loaded: on<Todo[]>((_s, items) => ({ items, status: "ready" as Status })),
+    loadFailed: on<string>((_s, error) => ({
       status: "ready" as Status,
       error,
     })),


### PR DESCRIPTION
Acts on the benchmark finding that dispatch was the one curve where re-reduced lost. **Stacks on #64** (the data-driven benchmark page) — review/merge that first; this branch regenerates its data to show the result.

## The finding
Measured: dispatch was O(fields), and the **eager snapshot** dominated — not the spread. Every dispatch peeked all signals to build the reducer's `prev`, and the `(state) => state` type *forced* a `...s` spread to change one field.

## The fix (1 + 2)
1. **State mirror** — keep a plain-object shadow of state, updated in the same commit loop that writes the signals. `getState()` clones it; dispatch reads it directly. No per-dispatch full peek. *(Not a proxy — that was tried, ~7× slower on spreads.)*
2. **Partial-return handlers** — return type is now `Partial<S>` (merged), input is `Readonly<S>`. A one-field update is `(s) => ({ count: s.count + 1 })`, no spread. Full-`S` returns still type-check → backward compatible. `Readonly<S>` makes mutating the live mirror a compile error at zero runtime cost.

## Result (recaptured, real data)
The scaling curve **flips**: re-reduced is now **flat ~35 ns** across 1→64 fields (~23× faster at 64), Zustand grows O(fields). Throughput 33 ns vs Zustand 56 ns.

| Fields | re-reduced | Zustand |
| --- | --- | --- |
| 1 | 35 ns | 45 ns |
| 64 | **35 ns** | 583 ns |

## Also
- ADR-0010 documents merge semantics + the mirror
- 4 new regression tests (merge, mirror sync, getState clone, minimal writes)
- adopt the idiom: `todos`, `life-store` setCell (O(900)→O(1)), bench probes
- benchmark page prose + chart captions rewritten to match

## Verify
52 tests pass (4 new) · all packages typecheck · `next build` ✓ · biome ✓ · scaling chart render-checked (flat re-reduced, rising Zustand)