### PR TITLE
chore(core): changeset for mirror dispatch + partial returns

### DIFF
--- a/.changeset/mirror-dispatch.md
+++ b/.changeset/mirror-dispatch.md
@@ -1,0 +1,12 @@
+---
+"@re-reduced/core": minor
+---
+
+O(1) dispatch via a state mirror, and partial-return action handlers.
+
+Handlers now return only the keys that changed (`Partial<S>`, merged into state) —
+a one-field update is `(s) => ({ count: s.count + 1 })`, no `...s` spread. `state`
+is passed read-only. The store keeps a plain-object mirror of state in sync with
+the signals, so dispatch is O(changed keys) instead of O(fields): a one-field bump
+is flat regardless of container size (~23× faster at 64 fields). Full-`S` returns
+still type-check, so existing handlers keep working. See ADR-0010.


### PR DESCRIPTION
#65 merged the O(1)-dispatch + partial-return change to `@re-reduced/core` without a changeset, so the next release wouldn't bump core or note it. This adds a **minor** changeset (dependents auto-patch via `updateInternalDependencies`).

Backfill — no code change.