### PR TITLE
fix(docs): fix nested twoslash codeblock borders

### DIFF
--- a/.changeset/mirror-dispatch.md
+++ b/.changeset/mirror-dispatch.md
@@ -1,0 +1,12 @@
+---
+"@re-reduced/core": minor
+---
+
+O(1) dispatch via a state mirror, and partial-return action handlers.
+
+Handlers now return only the keys that changed (`Partial<S>`, merged into state) —
+a one-field update is `(s) => ({ count: s.count + 1 })`, no `...s` spread. `state`
+is passed read-only. The store keeps a plain-object mirror of state in sync with
+the signals, so dispatch is O(changed keys) instead of O(fields): a one-field bump
+is flat regardless of container size (~23× faster at 64 fields). Full-`S` returns
+still type-check, so existing handlers keep working. See ADR-0010.

--- a/apps/docs/components/twoslash-snippet.tsx
+++ b/apps/docs/components/twoslash-snippet.tsx
@@ -30,7 +30,10 @@ export async function TwoslashSnippet({
     ],
     components: {
       pre: (props) => (
-        <CodeBlock {...props}>
+        <CodeBlock
+          {...props}
+          className="border-none bg-transparent rounded-none my-0 shadow-none [&_pre]:bg-transparent"
+        >
           <Pre>{props.children}</Pre>
         </CodeBlock>
       ),


### PR DESCRIPTION
Removes the double-border container layout issue on twoslash code snippets.