### PR TITLE
feat(react): context-bound hooks + destructuring reads

### DIFF
--- a/.changeset/destructure-hooks.md
+++ b/.changeset/destructure-hooks.md
@@ -1,0 +1,15 @@
+---
+"@re-reduced/react": minor
+---
+
+Context-bound hooks + destructuring reads (unstated-next ergonomics).
+
+`createContainerContext` now returns context-bound hooks so consumers never
+thread the store: `Counter.useContainer()` destructures values **and** actions in
+one object (`const { count, increment } = Counter.useContainer()`),
+`Counter.useSelect(sel)` reads one slice, `Counter.useActions()` the action map.
+`Counter.use()` still returns the raw Store.
+
+New standalone `useStoreValues(store)` returns a proxy over state + derived where
+reading a key during render subscribes the component to **that key only** — the
+per-field bail-out is preserved (destructure the keys you read; don't spread).

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -1,15 +1,34 @@
-import type { ActionSpec, ContainerDef, Store } from "@re-reduced/core";
+import type {
+  ActionSpec,
+  Actions,
+  ContainerDef,
+  DerivedSignals,
+  StateSignals,
+  Store,
+} from "@re-reduced/core";
 import {
   createContext,
   createElement,
   type ReactNode,
   useContext,
+  useMemo,
 } from "react";
-import { type UseContainerOptions, useContainer } from "./hooks";
+import {
+  type DerivedValues,
+  type UseContainerOptions,
+  useContainer,
+  useSelect,
+  useStoreValues,
+} from "./hooks";
 
 /**
- * Lift a Container to a subtree. Reads still go through `useSelect` (signals),
- * so selector bail-out is preserved — unlike raw Context value broadcast.
+ * Lift a Container to a subtree. Reads still go through signals, so selector
+ * bail-out is preserved — unlike raw Context value broadcast.
+ *
+ * The returned object carries context-bound hooks so consumers never thread the
+ * store: `Counter.useContainer()` destructures values + actions (unstated-next
+ * style), `Counter.useSelect(sel)` reads one slice, `Counter.useActions()` the
+ * action map. `Counter.use()` still returns the raw Store for escape hatches.
  */
 export function createContainerContext<
   S extends Record<string, unknown>,
@@ -36,5 +55,47 @@ export function createContainerContext<
     return store;
   }
 
-  return { Provider, use: useStore, Context: Ctx };
+  /** One slice, primitive/stable ref — preserves bail-out. */
+  function useCtxSelect<T>(
+    selector: (state: StateSignals<S>, derived: DerivedSignals<D>) => T,
+  ): T {
+    return useSelect(useStore(), selector);
+  }
+
+  /** The action map (stable callbacks). */
+  function useActions(): Actions<R> {
+    return useStore().actions;
+  }
+
+  /**
+   * Destructure values AND actions in one go (unstated-next ergonomics):
+   * `const { count, increment } = Counter.useContainer()`. Each value key
+   * tracked per-field; action keys win on a name clash. Destructure — don't
+   * spread.
+   */
+  function useContainerValues(): S & DerivedValues<D> & Actions<R> {
+    const store = useStore();
+    const values = useStoreValues(store);
+    return useMemo(
+      () =>
+        new Proxy({} as S & DerivedValues<D> & Actions<R>, {
+          get(_t, key) {
+            if (typeof key !== "string") return undefined;
+            if (key in (store.actions as object))
+              return (store.actions as Record<string, unknown>)[key];
+            return (values as Record<string, unknown>)[key];
+          },
+        }),
+      [store, values],
+    );
+  }
+
+  return {
+    Provider,
+    use: useStore,
+    useContainer: useContainerValues,
+    useSelect: useCtxSelect,
+    useActions,
+    Context: Ctx,
+  };
 }

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -91,3 +91,84 @@ export function useWatch<S, R, D extends Record<string, () => unknown>, T>(
   effectRef.current = effectFn;
   useEffect(() => effectRef.current(value), [value]);
 }
+
+/** Plain values of the derived block (the computed results, not the thunks). */
+export type DerivedValues<D> = {
+  [K in keyof D]: D[K] extends () => infer T ? T : never;
+};
+
+interface ValueSource {
+  peek(): unknown;
+  subscribe(run: () => void): () => void;
+}
+
+/**
+ * Destructuring read. Returns a proxy over state + derived where reading a key
+ * during render subscribes the component to THAT key only — the per-field
+ * bail-out is preserved, so `const { a } = useStoreValues(store)` re-renders
+ * only when `a` changes (same discipline as a primitive `useSelect`).
+ *
+ * Destructure the keys you read; do NOT spread or `Object.keys` the result —
+ * that touches every field and subscribes to all of them.
+ */
+export function useStoreValues<S, R, D extends Record<string, () => unknown>>(
+  store: Store<S, R, D>,
+): S & DerivedValues<D> {
+  const accessed = useRef<Set<string>>(new Set());
+  const snap = useRef<Record<string, unknown>>({});
+
+  const sources = useMemo(
+    () =>
+      ({ ...store.$state, ...store.$derived }) as Record<string, ValueSource>,
+    [store],
+  );
+
+  const subscribe = useMemo(
+    () => (onChange: () => void) => {
+      const unsubs = Object.keys(sources).map((k) =>
+        sources[k].subscribe(() => {
+          if (accessed.current.has(k)) onChange(); // gate: only accessed keys wake us
+        }),
+      );
+      return () => {
+        for (const u of unsubs) u();
+      };
+    },
+    [sources],
+  );
+
+  // Stable identity unless an *accessed* value changed → absorbs the spurious
+  // immediate-fire on subscribe and keeps useSyncExternalStore from re-rendering
+  // on untracked fields.
+  const getSnapshot = useMemo(
+    () => () => {
+      let changed = false;
+      for (const k of accessed.current) {
+        const v = sources[k].peek();
+        if (!Object.is(v, snap.current[k])) {
+          snap.current[k] = v;
+          changed = true;
+        }
+      }
+      if (changed) snap.current = { ...snap.current };
+      return snap.current;
+    },
+    [sources],
+  );
+
+  useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  return useMemo(
+    () =>
+      new Proxy({} as S & DerivedValues<D>, {
+        get(_t, key) {
+          if (typeof key !== "string") return undefined;
+          const sig = sources[key];
+          if (!sig) return undefined;
+          accessed.current.add(key); // tracked from now on
+          return sig.peek();
+        },
+      }),
+    [sources],
+  );
+}

--- a/packages/react/test/destructure.spec.tsx
+++ b/packages/react/test/destructure.spec.tsx
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { defineContainer } from "@re-reduced/core";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { createContainerContext } from "../src";
+
+const todos = defineContainer("todos", {
+  state: { draft: "", items: [] as string[] },
+  actions: (on) => ({
+    draftChanged: on<string>((s, draft) => ({ ...s, draft })),
+    addItem: on<string>((s, item) => ({ ...s, items: [...s.items, item] })),
+  }),
+  derive: (s) => ({ count: () => s.items.value.length }),
+});
+
+const Ctx = createContainerContext(todos);
+
+const counts = { draft: 0, list: 0, total: 0, controls: 0 };
+
+function DraftInput() {
+  const { draft, draftChanged } = Ctx.useContainer();
+  counts.draft += 1;
+  return (
+    <input
+      data-testid="input"
+      value={draft}
+      onChange={(e) => draftChanged(e.target.value)}
+    />
+  );
+}
+
+function List() {
+  const { items } = Ctx.useContainer();
+  counts.list += 1;
+  return (
+    <ul data-testid="list">
+      {items.map((it, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: test fixture
+        <li key={i}>{it}</li>
+      ))}
+    </ul>
+  );
+}
+
+function Total() {
+  const { count } = Ctx.useContainer(); // derived slice
+  counts.total += 1;
+  return <span data-testid="total">{count}</span>;
+}
+
+function Controls() {
+  const { addItem } = Ctx.useContainer();
+  counts.controls += 1; // reads only an action → subscribes to nothing
+  return (
+    <button type="button" data-testid="add" onClick={() => addItem("x")}>
+      add
+    </button>
+  );
+}
+
+const App = () => (
+  <Ctx.Provider>
+    <DraftInput />
+    <List />
+    <Total />
+    <Controls />
+  </Ctx.Provider>
+);
+
+describe("@re-reduced/react — destructured useContainer (real DOM)", () => {
+  beforeEach(() => {
+    counts.draft = 0;
+    counts.list = 0;
+    counts.total = 0;
+    counts.controls = 0;
+  });
+  afterEach(cleanup);
+
+  it("a draft keystroke re-renders only the input", () => {
+    const { getByTestId } = render(<App />);
+    const baseline = { ...counts };
+
+    fireEvent.change(getByTestId("input"), { target: { value: "a" } });
+
+    expect(counts.draft).toBe(baseline.draft + 1);
+    expect(counts.list).toBe(baseline.list);
+    expect(counts.total).toBe(baseline.total);
+    expect(counts.controls).toBe(baseline.controls);
+    expect((getByTestId("input") as HTMLInputElement).value).toBe("a");
+  });
+
+  it("adding an item re-renders the list and the derived total, not the input", () => {
+    const { getByTestId } = render(<App />);
+    const baseline = { ...counts };
+
+    fireEvent.click(getByTestId("add"));
+
+    expect(counts.list).toBe(baseline.list + 1);
+    expect(counts.total).toBe(baseline.total + 1); // count derived from items
+    expect(counts.draft).toBe(baseline.draft); // input did NOT
+    expect(counts.controls).toBe(baseline.controls); // action-only did NOT
+    expect(getByTestId("total").textContent).toBe("1");
+    expect(getByTestId("list").querySelectorAll("li").length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- `createContainerContext` returns context-bound `useContainer` / `useSelect` / `useActions`, so consumers no longer thread the store; `use()` still returns the raw Store
- `Counter.useContainer()` destructures values **and** actions in one object — `const { count, increment } = Counter.useContainer()` (unstated-next ergonomics)
- New standalone `useStoreValues(store)` proxy tracks accessed keys per-field, so destructuring preserves the signal bail-out (re-renders only on the keys a component reads)
- Adds a real-DOM test asserting destructured reads keep fine-grained re-renders across state and derived slices